### PR TITLE
[REL] base_ux: Migration to 13.0

### DIFF
--- a/base_ux/__manifest__.py
+++ b/base_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Base UX',
-    'version': '12.0.1.1.0',
+    'version': '13.0.1.0.0',
     'category': 'Base',
     'sequence': 14,
     'summary': '',
@@ -30,8 +30,7 @@
     ],
     'depends': [
         'base',
-        # depends on mail for tracking on fields
-        'mail',
+        'mail',  # depends on mail for tracking on fields
     ],
     'external_dependencies': {
         'python': ['openupgradelib'],
@@ -48,7 +47,7 @@
     ],
     'test': [
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
     'application': False,
 }

--- a/base_ux/models/ir_actions_act_window.py
+++ b/base_ux/models/ir_actions_act_window.py
@@ -4,23 +4,21 @@ from odoo import models, api
 class IrActionsActWindow(models.Model):
     _inherit = 'ir.actions.act_window'
 
-    @api.multi
     def create_action(self):
         """ Create a contextual action for each act window. """
         model = self.env['ir.model']
-        for rec in self.filtered('src_model'):
-            src_model = model.search([('model', '=', rec.src_model)])
-            rec.write({'binding_model_id': src_model.id,
+        for rec in self.filtered('res_model'):
+            res_model = model.search([('model', '=', rec.res_model)])
+            rec.write({'binding_model_id': res_model.id,
                        'binding_type': 'action'})
         return True
 
-    @api.multi
     def unlink_action(self):
         """ Remove the contextual actions created for the act window. """
         self.check_access_rights('write', raise_exception=True)
         self.filtered('binding_model_id').write({'binding_model_id': False})
         return True
 
-    @api.onchange('src_model')
+    @api.onchange('res_model')
     def update_binding_model_id(self):
         self.binding_model_id = False

--- a/base_ux/models/res_partner.py
+++ b/base_ux/models/res_partner.py
@@ -8,4 +8,4 @@ from odoo import models, fields
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    active = fields.Boolean(track_visibility='onchange')
+    active = fields.Boolean(tracking=True)

--- a/base_ux/views/ir_actions_act_window_view.xml
+++ b/base_ux/views/ir_actions_act_window_view.xml
@@ -11,7 +11,7 @@
             </field>
             <group position="before">
                 <button name="create_action" string="Add in the 'Action' menu" type="object"
-                    attrs="{'invisible':['|', ('src_model','=', False), ('binding_model_id', '!=', False)]}"
+                    attrs="{'invisible':['|', ('res_model','=', False), ('binding_model_id', '!=', False)]}"
                     help="Display an option on related documents to open this action"/>
                 <button name="unlink_action" string="Remove from the 'Action' menu" type="object"
                     attrs="{'invisible':[('binding_model_id','=',False)]}"

--- a/base_ux/views/ir_translation_view.xml
+++ b/base_ux/views/ir_translation_view.xml
@@ -6,8 +6,8 @@
         <field name="inherit_id" ref="base.view_translation_search"/>
         <field name="arch" type="xml">
 
-            <field name="source" position="before">
-                <field name="source" filter_domain="[('source', '=like', self)]" string="Source (exact term)"/>
+            <field name="src" position="before">
+                <field name="src" filter_domain="[('src', '=like', self)]" string="Source (exact term)"/>
             </field>
 
         </field>

--- a/base_ux/views/mail_template_view.xml
+++ b/base_ux/views/mail_template_view.xml
@@ -6,20 +6,23 @@
         <field name="model">mail.template</field>
         <field name="inherit_id" ref="mail.email_template_form"/>
         <field name="arch" type="xml">
-            <div name="button_box" position="inside">
-                <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                    <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                </button>
-            </div>
+            <form>
+                <field name="active" invisible="1"/>
+            </form>
         </field>
     </record>
 
-    <template id="view_mail_template_search" inherit_id="mail.view_email_template_search">
-        <field name="name" position="after">
-            <filter name="active" string="Active" domain="[('active', '=', True)]"/>
-            <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
+    <record id="view_mail_template_search" model="ir.ui.view">
+        <field name="name">mail.template.search_view</field>
+        <field name="model">mail.template</field>
+        <field name="inherit_id" ref="mail.view_email_template_search"/>
+        <field name="arch" type="xml">
+            <search>
+                <filter name="active" string="Active" domain="[('active', '=', True)]"/>
+                <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
+            </search>
         </field>
-    </template>
+    </record>
 
     <record id="view_mail_template_tree" model="ir.ui.view">
         <field name="name">view_mail_template_tree</field>

--- a/base_ux/views/res_company_view.xml
+++ b/base_ux/views/res_company_view.xml
@@ -6,13 +6,9 @@
         <field name="model">res.company</field>
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
-            <field name="logo" position="before">
-                <div class="oe_button_box" name="button_box">
-                    <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                        <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                    </button>
-                </div>
-            </field>
+            <form>
+                <field name="active" invisible="1"/>
+            </form>
         </field>
     </record>
 

--- a/base_ux/wizards/merge_records.py
+++ b/base_ux/wizards/merge_records.py
@@ -130,7 +130,6 @@ class MergeRecords(models.TransientModel):
     #     for rec in self:
     #         rec.line_ids = rec.update_merge_lines()
 
-    @api.multi
     def update_merge_lines(self):
         model = self.env[self.model_id.model] if self else self.env[
             self.env.context.get('active_model')]
@@ -161,7 +160,6 @@ class MergeRecords(models.TransientModel):
             })]
         return res
 
-    @api.multi
     def action_merge(self):
         """ Merge records button. Merge the selected records, and redirect to
             the merged record form view.

--- a/base_ux/wizards/merge_records_view.xml
+++ b/base_ux/wizards/merge_records_view.xml
@@ -23,7 +23,7 @@
                             <label for="field_spec" name="field_spec"/>
                             <div>
                             <field name="field_spec" placeholder="{'field_name': 'operation'}" class="oe_inline"/>
-                            <a href="https://github.com/OCA/openupgradelib/blob/fb978d75711a062822b472892de23b33827614ad/openupgradelib/openupgrade_merge_records.py#L243-L278" target="_blank" title="Check all available operations (openupgradelib._adjust_merged_values_orm method)"><i class="fa fa-fw fa-question-circle"/>Check Available Options</a>
+                            <a href="https://github.com/OCA/openupgradelib/blob/fb978d75711a062822b472892de23b33827614ad/openupgradelib/openupgrade_merge_records.py#L243-L278" target="_blank" title="Check all available operations (openupgradelib._adjust_merged_values_orm method)" class="fa fa-fw fa-question-circle"/>
                             </div>
                             <field name="line_id" domain="[('id', 'in', line_ids or False)]" options="{'no_create': True}, 'no_create_edit': True" required="1"/>
                         </group>
@@ -48,7 +48,6 @@
     <record id="merge_records_action" model="ir.actions.act_window">
         <field name="name">Merge Records</field>
         <field name="res_model">merge.records</field>
-        <field name="view_type">form</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
     </record>


### PR DESCRIPTION
task 21855

* make module installable
* update module version
* remove api multi
* remove deprecated keys in manifest
* update depreacted src_model with binding_model_id
* update deprecated track_visibility=... with tracking=True
* update renamed field source to src in ir.translation
* remove stat buttons from res.company and mail.template, only add active to the view as invisible field.
* fix mail.template search view was not properly defined.
* apapt merge records wizard view, remove button name, only show icon and tooltip