### PR TITLE
[IMP] base_ux: activities onchange

### DIFF
--- a/base_ux/README.rst
+++ b/base_ux/README.rst
@@ -24,6 +24,7 @@ Several Improvements:
     * Be able to use re python library and odoo.tools.html2plaintext()function in server actions, ir.cron, base.automation, etc.
     * Make parent field on res.company invisible as it is useless now
     * New generic wizard that leave us to merge records of any model, By the moment this can be used only via migration script or server action.
+    * Keep the activity's description when changing the activity type, regardless of the activity type's description, and change the activity user only if the activity type has a default user.
 
     **NOTE:** In order to use it you can go to server actions menu, search by "Merge Records" action and there:
 

--- a/base_ux/models/__init__.py
+++ b/base_ux/models/__init__.py
@@ -8,3 +8,4 @@ from . import res_country_state
 from . import res_company
 from . import mail_template
 from . import ir_actions_server
+from . import mail_activity

--- a/base_ux/models/mail_activity.py
+++ b/base_ux/models/mail_activity.py
@@ -1,0 +1,21 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, fields, models
+
+class MailActivity(models.Model):
+    _inherit = 'mail.activity'
+
+    @api.onchange('activity_type_id')
+    def _onchange_activity_type_id(self):
+        """ overrides original method: keep the activity description when
+        changing the activity type, regardless of the activity type's description,
+        and change the activity user only if the activity type has a default user """
+        note = self.note
+        user = self.user_id
+        super()._onchange_activity_type_id()
+        if user and user != self.user_id and not self.activity_type_id.default_user_id:
+            self.user_id = user
+        if note != '<p><br></p>' and note != False and note != self.note:
+            self.note = note


### PR DESCRIPTION
Keep the activity's description when changing the activity type, regardless of the activity type's description, and change the activity user only if the activity type has a default user.