### PR TITLE
[ADD] crm_mail_tracking: new module to prevent errors

### DIFF
--- a/crm_mail_tracking/README.rst
+++ b/crm_mail_tracking/README.rst
@@ -1,0 +1,63 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=========================
+    CRM Mail Tracking
+=========================
+
+
+This module addresses a specific issue in message handling within the Odoo CRM. A method has been modified to prevent errors when a key field (email_from) is not present. Installing this module provides a solution to this problem.
+
+Installation
+============
+
+Only install the module.
+
+Configuration
+=============
+
+There is nothing to configure.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/miscellaneous/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/crm_mail_tracking/__init__.py
+++ b/crm_mail_tracking/__init__.py
@@ -1,0 +1,6 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from . import models

--- a/crm_mail_tracking/__manifest__.py
+++ b/crm_mail_tracking/__manifest__.py
@@ -1,0 +1,42 @@
+##############################################################################
+#
+#    Copyright (C) 2019  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'CRM Mail Tracking',
+    'version': '16.0.1.0.0',
+    'category': 'Base',
+    'sequence': 14,
+    'summary': '',
+    'author': 'ADHOC SA',
+    'website': 'www.adhoc.com.ar',
+    'license': 'AGPL-3',
+    'images': [
+    ],
+    'depends': [
+        'crm',
+        'mail_tracking',
+    ],
+    'data': [
+    ],
+    'demo': [
+    ],
+    'installable': True,
+    'auto_install': True,
+    'application': False,
+}

--- a/crm_mail_tracking/models/__init__.py
+++ b/crm_mail_tracking/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_thread

--- a/crm_mail_tracking/models/mail_thread.py
+++ b/crm_mail_tracking/models/mail_thread.py
@@ -1,0 +1,14 @@
+from odoo import models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    def _add_extra_recipients_suggestions(self, suggestions, field_mail, reason):
+        """
+        Agregamos este método debido a que cuando en el CRM no hay un email_from, al
+        llamar a _message_partner_info_from_emails termina dando error porque no verifica
+        si tiene un email_from y utiliza email_from.lower()
+        """
+        if not (self._name == 'crm.lead' and not self.email_from):
+            super()._add_extra_recipients_suggestions(self, suggestions, field_mail, reason)


### PR DESCRIPTION
Se ha modificado un método para evitar errores cuando un campo clave (email_from) no está presente y que termina saliendo un error al ingresar a las oportunidades.
Esto pasa cuando está instalado crm y mail_tracking al ingresar en las leads. 
Ticket: #70554