### PR TITLE
[FIX] portal_backend: change the backend portal category 

### DIFF
--- a/portal_backend/security/res_groups.xml
+++ b/portal_backend/security/res_groups.xml
@@ -9,7 +9,7 @@
     <!-- Portal backend user group -->
     <record id="group_portal_backend" model="res.groups">
         <field name="name">Portal Backend</field>
-        <field name="category_id" ref="base.module_category_user_type"/>
+        <field name="category_id" ref="category_portal_advanced"/>
         <field name="implied_ids" eval="[Command.link(ref('base.group_portal'))]"/>
     </record>
 


### PR DESCRIPTION
Cambiamos la categoría del tipo de usuario para evitar que salte la constrains del chequeo de más de un tipo de usuario al actualizar el módulo hr_holidays (puede pasar con otros módulos) 
https://github.com/odoo/odoo/blob/8377837c034ae0fb572b98dc24d0d28359409b2e/odoo/addons/base/models/res_users.py#L570
Al cambiar la categoría tuve que editar el método que crea la vista y me ponga el grupo de portal backend junto con los otros grupos de tipos de usuarios
![image](https://github.com/user-attachments/assets/a16b026c-8fd1-404b-a0b2-36ba0c22979f)
