### PR TITLE
[IMP] portal_holidays: allow creating new leave allocation request

### DIFF
--- a/portal_holidays/__manifest__.py
+++ b/portal_holidays/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Portal Holidays",
-    "version": "18.0.1.4.0",
+    "version": "18.0.1.5.0",
     "category": "Base",
     "sequence": 14,
     "summary": "",
@@ -32,8 +32,9 @@
         "security/res_groups.xml",
         "security/ir_rule.xml",
         "security/ir.model.access.csv",
-        "views/base_menus.xml",
         "views/hr_employee_views.xml",
+        "views/portal_holidays_views.xml",
+        "views/base_menus.xml",
     ],
     "demo": [
         "demo/hr_demo.xml",

--- a/portal_holidays/models/hr_leave_allocation.py
+++ b/portal_holidays/models/hr_leave_allocation.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import AccessError
 
 
 class HolidaysAllocation(models.Model):
@@ -9,3 +10,19 @@ class HolidaysAllocation(models.Model):
     employee_overtime = fields.Float(
         related="employee_id.total_overtime", groups="base.group_user,portal_holidays.group_portal_backend_holiday"
     )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """
+        Allows users in the portal holidays group to create allocation records
+        only for themselves. If the user passes the check, the method runs with
+        elevated privileges to bypass access restrictions if necessary.
+        """
+        if self.env.user.has_group("portal_holidays.group_portal_backend_holiday"):
+            user_employee_id = self.env.user.employee_id.id
+            for vals in vals_list:
+                if vals.get("employee_id") != user_employee_id:
+                    raise AccessError(_("You can only create allocations for yourself."))
+            self = self.sudo()
+
+        return super().create(vals_list)

--- a/portal_holidays/views/base_menus.xml
+++ b/portal_holidays/views/base_menus.xml
@@ -3,4 +3,31 @@
     <record id="hr_holidays.menu_hr_holidays_root" model="ir.ui.menu">
         <field name="groups_id" eval="[Command.link(ref('portal_holidays.group_portal_backend_holiday'))]"/>
     </record>
+
+    <!-- Restrict new portal holidays menus to base group_user -->
+    <record id="hr_holidays.hr_leave_menu_my" model="ir.ui.menu">
+        <field name="groups_id" eval="[Command.set([ref('base.group_user')])]"/>
+    </record>
+
+    <record id="hr_holidays.menu_open_allocation" model="ir.ui.menu">
+        <field name="groups_id" eval="[Command.set([ref('base.group_user')])]"/>
+    </record>
+
+    <!-- Add portal holidays menu for My Time Off -->
+    <menuitem
+        id="hr_leave_menu_my_portal_holidays"
+        name="My Time Off"
+        parent="hr_holidays.menu_hr_holidays_my_leaves"
+        action="hr_leave_action_my_portal_holidays"
+        sequence="2"
+        groups="portal_holidays.group_portal_backend_holiday"/>
+
+    <!-- Add portal holidays menu for My Allocations -->
+    <menuitem
+        id="menu_open_allocation_portal_holidays"
+        name="My Allocations"
+        parent="hr_holidays.menu_hr_holidays_my_leaves"
+        action="hr_leave_allocation_action_my_portal_holidays"
+        sequence="3"
+        groups="portal_holidays.group_portal_backend_holiday"/>
 </odoo>

--- a/portal_holidays/views/portal_holidays_views.xml
+++ b/portal_holidays/views/portal_holidays_views.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Add My Time Off Action for portal holidays users -->
+    <record id="hr_leave_action_my_portal_holidays" model="ir.actions.act_window">
+        <field name="name">My Time Off</field>
+        <field name="res_model">hr.leave</field>
+        <field name="view_mode">list,kanban</field>
+        <field name="context">{"search_default_group_date_from": True}</field>
+        <field name="search_view_id" ref="hr_holidays.hr_leave_view_search_my"/>
+        <field name="domain">[('user_id', '=', uid)]</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Keep track of your PTOs.
+            </p><p>
+                A great way to keep track on your time off requests, sick days, and approval status.
+            </p>
+        </field>
+    </record>
+
+    <record id="hr_leave_action_my_view_tree_portal_holidays" model="ir.actions.act_window.view">
+        <field name="sequence">1</field>
+        <field name="view_mode">list</field>
+        <field name="act_window_id" ref="hr_leave_action_my_portal_holidays"/>
+        <field name="view_id" ref="hr_holidays.hr_leave_view_tree_my"/>
+    </record>
+
+    <!-- Add My Allocations Action for portal holidays users -->
+    <record id="hr_leave_allocation_action_my_portal_holidays" model="ir.actions.act_window">
+        <field name="name">My Allocations</field>
+        <field name="res_model">hr.leave.allocation</field>
+        <field name="view_mode">list,kanban</field>
+        <field name="search_view_id" ref="hr_holidays.hr_leave_allocation_view_search_my"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new time off allocation request
+            </p><p>
+                Time Off Officers allocate time off days to employees (e.g. paid time off).<br/>
+                Employees request allocations to Time Off Officers (e.g. recuperation days).
+            </p>
+        </field>
+        <field name="context">{'search_default_year': 1 , 'is_employee_allocation': True}</field>
+        <field name="domain">[('employee_id.user_id', '=', uid)]</field>
+    </record>
+
+    <record id="hr_leave_allocation_action_my_view_tree_portal_holidays" model="ir.actions.act_window.view">
+        <field name="sequence">1</field>
+        <field name="view_mode">list</field>
+        <field name="act_window_id" ref="hr_leave_allocation_action_my_portal_holidays"/>
+        <field name="view_id" ref="hr_holidays.hr_leave_allocation_view_tree_my"/>
+    </record>
+</odoo>


### PR DESCRIPTION
Enables portal holidays users to submit new leave allocation requests by elevating their privileges, and adds corresponding menu items and actions.

-Override create in hr.leave.allocation to allow portal holidays group users to create allocations
-Add “My Time Off” and “My Allocations” actions/views for portal holidays users
-Update menus to expose new actions only to portal holidays users

