### PR TITLE
[FIX] export_bg: Handle binary values in JSON export

### DIFF
--- a/export_bg/models/export_bg_mixin.py
+++ b/export_bg/models/export_bg_mixin.py
@@ -14,6 +14,8 @@ class DateTimeEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, (datetime, date, time)):
             return obj.isoformat()
+        if isinstance(obj, (bytes, bytearray, memoryview)):
+            return base64.b64encode(bytes(obj)).decode()
         return super().default(obj)
 
 


### PR DESCRIPTION
Encode bytes/bytearray/memoryview values as base64 strings during JSON export. Remove the leftover debugger breakpoint.