### PR TITLE
[FIX] base_company_dependent: protect company_dependent M2o fields fr…

### DIFF
--- a/base_company_dependent/models/__init__.py
+++ b/base_company_dependent/models/__init__.py
@@ -1,2 +1,2 @@
-from . import ir_ui_view
 from . import base_company_dependent
+from . import base

--- a/base_company_dependent/models/base.py
+++ b/base_company_dependent/models/base.py
@@ -1,0 +1,74 @@
+##############################################################################
+#
+#    Copyright (C) 2024  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class Base(models.AbstractModel):
+    """Exposes ``company_dependent`` to the frontend widget and blocks
+    cross-company contamination on imports (UI and module CSV data) by
+    validating company_dependent Many2one values inside ``load()``."""
+
+    _inherit = "base"
+
+    @api.model
+    def _get_view_field_attributes(self):
+        keys = super()._get_view_field_attributes()
+        keys.append("company_dependent")
+        return keys
+
+    @api.model
+    def load(self, fields, data):
+        result = super().load(fields, data)
+        loaded_ids = [rid for rid in (result.get("ids") or []) if rid]
+        if loaded_ids:
+            self.browse(loaded_ids)._check_company_dependent_m2o()
+        return result
+
+    def _check_company_dependent_m2o(self):
+        """Raise ValidationError if any company_dependent Many2one on this
+        recordset belongs to a company other than ``self.env.company``."""
+        company = self.env.company
+        cd_fields = [f for f in self._fields.values() if f.type == "many2one" and f.company_dependent]
+        for field in cd_fields:
+            comodel = self.env[field.comodel_name]
+            company_domain = comodel._check_company_domain(company)
+            if not company_domain:
+                continue
+            for record in self:
+                # sudo to bypass ir.rules on the m2o target; company context is preserved
+                value = record.sudo()[field.name]
+                if not value:
+                    continue
+                if (
+                    comodel.sudo()
+                    .with_context(active_test=False)
+                    .search(company_domain + [("id", "=", value.id)], limit=1)
+                ):
+                    continue
+                raise ValidationError(
+                    _(
+                        "%(field)s '%(value)s' belongs to a different company "
+                        "and cannot be used with company '%(company)s'.",
+                        field=field.string,
+                        value=value.display_name,
+                        company=company.name,
+                    )
+                )

--- a/base_company_dependent/tests/__init__.py
+++ b/base_company_dependent/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_base_company_dependent
+from . import test_company_cross_check

--- a/base_company_dependent/tests/company_dependent_models.py
+++ b/base_company_dependent/tests/company_dependent_models.py
@@ -17,22 +17,17 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from odoo import api, models
+from odoo import fields, models
 
 
-class Base(models.AbstractModel):
-    """Expone el atributo ``company_dependent`` al cliente web.
+class CompanyDependentTester(models.Model):
+    """Transient model registered only during the tests (added to the registry
+    in setUpClass, rolled back by TransactionCase). Gives the suite a
+    company_dependent Many2one so the protection can be tested without account."""
 
-    ``_get_view_field_attributes`` controla qué metadatos de campo se incluyen
-    en la respuesta del ORM al cargar una vista.  ``company_dependent`` no está
-    en la lista base de Odoo 19, por lo que el frontend nunca lo recibe y no
-    puede activar el widget multicompañía.
-    """
+    _name = "company.dependent.tester"
+    _description = "Company Dependent Tester (tests only)"
 
-    _inherit = "base"
-
-    @api.model
-    def _get_view_field_attributes(self):
-        keys = super()._get_view_field_attributes()
-        keys.append("company_dependent")
-        return keys
+    name = fields.Char()
+    partner_id = fields.Many2one("res.partner", company_dependent=True)
+    partner_regular_id = fields.Many2one("res.partner")

--- a/base_company_dependent/tests/test_company_cross_check.py
+++ b/base_company_dependent/tests/test_company_cross_check.py
@@ -1,0 +1,137 @@
+##############################################################################
+#
+#    Copyright (C) 2024  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestCompanyCrossCheck(TransactionCase):
+    """End-to-end coverage for the cross-company protection on
+    company_dependent Many2one fields, through load().
+
+    The check lives exclusively in load() — the entry point for UI imports
+    and module CSV data — so write()/create() are intentionally unchecked.
+
+    Uses a transient ``company.dependent.tester`` model (registered only for
+    this run, rolled back by TransactionCase) so the protection is exercised
+    without depending on ``account``.
+    """
+
+    MODEL = "company.dependent.tester"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._register_test_model()
+
+        cls.company_a = cls.env.company
+        cls.company_b = cls.env["res.company"].create({"name": "E2E Company B"})
+        cls.test_actor = cls.env.ref("base.user_admin")
+
+        cls.partner_a = cls.env["res.partner"].create({"name": "E2E Partner A", "company_id": cls.company_a.id})
+        cls.partner_b = cls.env["res.partner"].create({"name": "E2E Partner B", "company_id": cls.company_b.id})
+        cls.partner_shared = cls.env["res.partner"].create({"name": "E2E Shared Partner", "company_id": False})
+
+    @classmethod
+    def _register_test_model(cls):
+        from odoo.orm.model_classes import add_to_registry
+
+        from . import company_dependent_models
+
+        add_to_registry(cls.registry, company_dependent_models.CompanyDependentTester)
+        cls.registry._setup_models__(cls.env.cr, [cls.MODEL])
+        cls.registry.init_models(cls.env.cr, [cls.MODEL], {"models_to_check": True})
+        cls.addClassCleanup(cls.registry.__delitem__, cls.MODEL)
+        # Group-less ACL so the non-superuser test actor can operate the model.
+        cls.env["ir.model"]._reflect_models([cls.MODEL])
+        cls.env["ir.model.access"].create(
+            {
+                "name": "company_dependent_tester_test",
+                "model_id": cls.env["ir.model"]._get(cls.MODEL).id,
+                "perm_read": True,
+                "perm_write": True,
+                "perm_create": True,
+                "perm_unlink": True,
+            }
+        )
+
+    def _env_a(self):
+        ctx = dict(self.env.context, allowed_company_ids=[self.company_a.id])
+        return self.env(user=self.test_actor, context=ctx)
+
+    def _load(self, env, partner):
+        """Helper: import a single row via load() into company.dependent.tester."""
+        return env[self.MODEL].load(
+            ["name", "partner_id/.id"],
+            [["Tester", str(partner.id)]],
+        )
+
+    def test_load_cross_company_raises(self):
+        """load() with a cross-company value raises ValidationError."""
+        with self.assertRaises(ValidationError):
+            self._load(self._env_a(), self.partner_b)
+
+    def test_load_own_company_passes(self):
+        """load() with an own-company value succeeds and returns an id."""
+        result = self._load(self._env_a(), self.partner_a)
+        self.assertTrue(result.get("ids"), "Expected a created record id")
+
+    def test_load_company_id_false_never_blocked(self):
+        """load() with a shared value (company_id=False) is never blocked."""
+        result = self._load(self._env_a(), self.partner_shared)
+        self.assertTrue(result.get("ids"))
+
+    def test_load_non_company_dependent_field_ignored(self):
+        """load() on a regular (non company_dependent) Many2one is never checked."""
+        env = self._env_a()
+        result = env[self.MODEL].load(
+            ["name", "partner_regular_id/.id"],
+            [["Tester", str(self.partner_b.id)]],
+        )
+        self.assertTrue(result.get("ids"))
+
+    def test_sibling_branch_domain_behavior_documented(self):
+        """Lock the sibling-branch behavior, whatever _check_company_domain does.
+
+        Standard Odoo excludes a sibling branch's records from the domain, so
+        the guard raises. A branch-aware override would make them visible and
+        the guard would pass. The test asserts whichever holds, catching a shift.
+        """
+        branch_1 = self.env["res.company"].create({"name": "Sibling Branch 1", "parent_id": self.company_a.id})
+        branch_2 = self.env["res.company"].create({"name": "Sibling Branch 2", "parent_id": self.company_a.id})
+        partner_of_branch_2 = self.env["res.partner"].create({"name": "Partner of Branch 2", "company_id": branch_2.id})
+        self.test_actor.sudo().write({"company_ids": [(4, branch_1.id), (4, branch_2.id)]})
+        ctx = dict(self.env.context, allowed_company_ids=[branch_1.id])
+        env_branch_1 = self.env(user=self.test_actor, context=ctx)
+
+        company_domain = self.env["res.partner"]._check_company_domain(branch_1)
+        sibling_accessible = bool(
+            self.env["res.partner"]
+            .sudo()
+            .with_context(active_test=False)
+            .search(company_domain + [("id", "=", partner_of_branch_2.id)], limit=1)
+        )
+
+        if sibling_accessible:
+            result = self._load(env_branch_1, partner_of_branch_2)
+            self.assertTrue(result.get("ids"))
+        else:
+            with self.assertRaises(ValidationError):
+                self._load(env_branch_1, partner_of_branch_2)


### PR DESCRIPTION
…om cross-company writes

Adds validation in the base ORM write/create to prevent a company_dependent Many2one field from being set to a record belonging to a different company than env.company. Without this fix, importing a product with an account from Company A while logged into Company B silently contaminated the JSONB column, causing "Invalid Operation" errors when creating invoices.

Odoo's built-in check_company mechanism skips company_dependent fields unless they are explicitly annotated with check_company=True (which most fields are not). This fix closes that gap transparently for all models without requiring per-field annotation. sudo() context is exempt to allow administrative and migration operations.

Also merges the two base-inheriting classes in the module into one file (resolves pylint R8180).