### PR TITLE
[IMP] base_company_dependent: extend widget to settings, ORM-mode fields and dark mode

### DIFF
--- a/base_company_dependent/README.rst
+++ b/base_company_dependent/README.rst
@@ -24,39 +24,39 @@ viendo:
 Esto genera confusión al editar: el usuario puede modificar accidentalmente el
 valor de *todas* las compañías (el default) pensando que solo toca la suya.
 
+Adicionalmente, hay dos casos especiales donde el almacenamiento no es JSONB
+directo:
+
+* **Campos ``related``** (típicos en ``res.config.settings`` con
+  ``related='company_id.xxx'``) → el valor real vive en ``res.company``.
+* **Campos ``computed``/``inverse``** (ej. ``standard_price`` en
+  ``product.template``, cuyo valor vive en ``product.product``).
+
+El widget soporta los tres casos detectando automáticamente la estrategia.
+
 Solución
 ========
-
-Se añade un **widget inteligente multicompañía** a todos los campos
-``Many2one`` marcados con ``company_dependent=True``:
 
 Indicador visual en el formulario
 ----------------------------------
 
-* **Ícono** ``fa-building-o`` a la derecha del campo.
-
-  * Color **primario** (azul) → valor específico para la compañía activa.
-  * Color **gris** → valor por defecto/fallback.
-
-* El texto del campo se renderiza en **gris/cursiva** cuando es el fallback.
+* **Ícono** ``fa-building-o`` a la derecha del campo, color **primario** (azul)
+  cuando hay valor específico para la compañía activa, **gris** cuando es
+  fallback.
+* El texto del campo se renderiza en **gris/muted** cuando es el fallback.
 
 Asistente multicompañía (Modal)
 ---------------------------------
 
-Al pulsar el ícono se abre un diálogo con una tabla de todas las compañías
-accesibles para el usuario (``env.companies``):
+Al pulsar el ícono se abre un diálogo con una tabla jerárquica (hasta 3
+niveles: padre → hija → nieta) de todas las compañías accesibles para el
+usuario (``env.companies``):
 
-+------------+----------------------------------+---------------+------------------+
-| Compañía   | Valor                            | Estado        | Acción           |
-+============+==================================+===============+==================+
-| Cía A      | Autocomplete Many2one            | Específico    | [\|Reset\|]      |
-+------------+----------------------------------+---------------+------------------+
-| Cía B      | (vacío)                          | Por Defecto   | [\|Reset\|] (×)  |
-+------------+----------------------------------+---------------+------------------+
-
-* **Vaciar** el Many2one guarda ``false`` en el JSON → campo vacío *explícito*
-  (badge «Específico»).
-* **Reset** *elimina* la clave del JSON → el campo vuelve al fallback global.
+* **Editar** valores por compañía sin cambiar de sesión.
+* **Reset** restaura el fallback global (elimina la clave del JSON).
+* **Copy to children** propaga el valor de una compañía padre a sus hijas
+  accesibles (salta las que no pasan validaciones de compañía).
+* Indicadores visuales por nivel y badge ``Specific``/``Default``.
 
 Diferencia clave Vaciar vs. Reset
 ''''''''''''''''''''''''''''''''''
@@ -69,45 +69,91 @@ Diferencia clave Vaciar vs. Reset
 | Reset  | ``{}`` (clave eliminada)           | Por Defecto      |
 +--------+------------------------------------+------------------+
 
-Fase MVP (implementada)
-========================
+**Reset en ORM-mode:** cuando el target real no es un campo JSONB nativo
+(p. ej. una columna propia de ``res.company`` expuesta como ``related`` desde
+``res.config.settings``) no hay clave que eliminar — cada compañía es su
+propio registro. En esos casos *Reset* equivale a vaciar al falsy del tipo
+(``False`` / ``0`` / ``""``); el badge "Por Defecto" sigue siendo informativo
+pero no implica que el valor venga de un fallback global.
 
-* Soporte para campos ``Many2one``.
-* Indicador visual gris/color-primario.
-* Modal funcional: listar, editar, resetear.
-* Caché por formulario: una sola query SQL para todos los campos
-  ``company_dependent`` del modelo.
+Tipos de campo soportados
+==========================
 
-Fase 2 (pendiente)
-==================
+El widget se inyecta automáticamente en los siguientes tipos de campo cuando
+``company_dependent=True``:
 
-* Soporte para campos ``Float`` e ``Integer``.
-* Botón «Copiar a todas las compañías hijas».
+* ``Many2one``
+* ``Char``
+* ``Integer``
+* ``Float``
+* ``Monetary``
+* ``Boolean``
+* ``Selection``
+* ``Date`` / ``DateTime``
+
+También aplica por *opt-in* explícito vía
+``options="{'company_dependent_mode': 'orm'}"`` para campos computed/related
+que exponen comportamiento company-dependent vía el ORM (sin columna JSONB).
+
+Integración con ``res.config.settings``
+========================================
+
+El ícono ``fa-building-o`` que Odoo renderiza automáticamente en
+``<setting company_dependent="1">`` se reemplaza por el botón interactivo del
+widget. Funciona tanto cuando el campo es el primer hijo del ``<setting>``
+(caso común) como cuando está envuelto en un ``<div>`` con ``<label>`` previo
+(detección por DOM del primer campo visible).
+
+Modo claro y oscuro
+====================
+
+Los estilos del diálogo usan variables CSS Bootstrap 5.3+ dark-aware
+(``--bs-tertiary-bg``, ``--bs-secondary-bg``, ``--bs-emphasis-color-rgb``),
+por lo que el contraste se mantiene correctamente en ambos temas.
 
 Arquitectura técnica
 ====================
 
-Backend
--------
+Backend (``base.company.dependent`` AbstractModel)
+---------------------------------------------------
 
-``base.company.dependent`` (``models.AbstractModel``):
-
-* ``get_company_dependent_values(res_model, res_id, field_name)``
-  → valores crudos por compañía (para el modal).
-* ``set_company_dependent_values(res_model, res_id, field_name, values_dict)``
-  → escribe el JSON crudo (soporta ``RESET``).
+* ``get_company_dependent_values(res_model, res_id, field_name, mode=None)``
+  → valores por compañía con jerarquía. ``mode`` auto-detecta ``'json'`` vs
+  ``'orm'``.
+* ``set_company_dependent_values(res_model, res_id, field_name, values_dict,
+  mode=None)`` → escribe valores; soporta ``"RESET"`` para eliminar la clave
+  del JSON.
 * ``get_company_dependent_meta(res_model, res_id)``
-  → ``{field_name: is_specific}`` en una sola query (para el indicador visual).
+  → ``{field_name: is_specific}`` en una sola query para todos los campos CD
+  del modelo (incluye campos computed con ``depends_context('company')``).
+* ``_detect_field_strategy(res_model, field_name)``
+  → decide ``'json'`` (CD nativo + store) vs ``'orm'`` (computed/related
+  vía ``with_company``).
+* ``_resolve_orm_target(res_model, res_id, field_name)``
+  → para campos no-JSON, resuelve al modelo/registro real donde escribir:
+
+  * ``res.config.settings`` con ``related='company_id.xxx'`` →
+    ``res.company`` directo.
+  * ``product.template.standard_price`` con variante única →
+    ``product.product``.
 
 Frontend (OWL)
---------------
+---------------
 
-* **Servicio** ``company_dependent``: caché por registro, batching de RPCs.
-* **Patch** ``Many2OneField``: carga meta en ``onWillStart``, inyecta el
-  sub-componente y el template extendido.
-* **``CompanyDependentButton``**: ícono con tooltip dinámico, abre el diálogo.
-* **``CompanyDependentDialog``**: tabla interactiva con ``AutoComplete`` para
-  Many2one y soporte de Reset.
+* **Servicio** ``company_dependent``: caché por registro, batching de RPCs
+  ``get_company_dependent_meta`` para todos los campos CD de un formulario.
+* **Patches** sobre ``Many2OneField``, ``CharField``, ``IntegerField``,
+  ``FloatField``, ``MonetaryField``, ``BooleanField``, ``SelectionField``,
+  ``DateTimeField`` (vía ``fields_patch.js``): inyectan
+  ``CompanyDependentButton`` y aplican la clase ``o_cd_fallback``.
+* **Patch** sobre ``Setting`` / ``SearchableSetting`` (``settings_patch.js``):
+  reemplaza el icono estático por el botón interactivo en
+  ``res.config.settings``.
+* **``CompanyDependentButton``**: botón con tooltip dinámico, abre el
+  diálogo.
+* **``CompanyDependentDialog``**: tabla jerárquica con AutoComplete /
+  SelectMenu / inputs según el tipo de campo, soporte de Copy-to-children
+  y Reset.
 
 Instalación
 ===========
@@ -115,13 +161,14 @@ Instalación
 .. code-block:: bash
 
    # Instalar desde la interfaz de Odoo o con:
-   odoo-bin -d <db> -u base_company_dependent
+   odoo-bin -d <db> -i base_company_dependent
 
 Dependencias
 ============
 
 * ``base``
 * ``web``
+* ``product``
 
 Licencia
 ========

--- a/base_company_dependent/__manifest__.py
+++ b/base_company_dependent/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Base Company Dependent UX",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.2.0",
     "category": "Base",
     "sequence": 14,
     "summary": (
@@ -30,13 +30,15 @@
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",
     "images": [],
-    "depends": ["base", "web"],
+    "depends": ["base", "web", "product"],
     "assets": {
         "web.assets_backend": [
             "base_company_dependent/static/src/**/*",
         ],
     },
-    "data": [],
+    "data": [
+        "views/product_template_views.xml",
+    ],
     "installable": True,
     "auto_install": False,
     "application": False,

--- a/base_company_dependent/models/base_company_dependent.py
+++ b/base_company_dependent/models/base_company_dependent.py
@@ -124,6 +124,370 @@ class BaseCompanyDependent(models.AbstractModel):
         return Domain.TRUE
 
     # ------------------------------------------------------------------
+    # Detección de estrategia (JSON directo vs ORM puro)
+    # ------------------------------------------------------------------
+
+    def _detect_field_strategy(self, res_model, field_name):
+        """Determina si un campo debe usar lectura JSONB directa o ORM puro.
+
+        :returns: ``'json'`` si el campo es un company_dependent nativo con
+                  columna JSONB, ``'orm'`` si es computed/related/inverse que
+                  expone datos company_dependent a través de la API ORM.
+        """
+        field = self.env[res_model]._fields.get(field_name)
+        if not field:
+            raise ValueError(f"El campo '{field_name}' no existe en '{res_model}'.")
+
+        # Caso nativo: company_dependent + stored → JSONB directo
+        if field.company_dependent and field.store:
+            return "json"
+
+        # Caso ORM: computed con depends_context('company')
+        if "company" in (getattr(field, "depends_context", None) or ()):
+            return "orm"
+
+        # Caso related: seguir la cadena hasta el campo real
+        if field.related:
+            return self._detect_related_strategy(res_model, field)
+
+        raise ValueError(
+            f"El campo '{field_name}' en '{res_model}' no es company_dependent " f"ni depende del contexto de compañía."
+        )
+
+    def _detect_related_strategy(self, res_model, field):
+        """Sigue la cadena ``related`` para detectar si el campo destino es CD."""
+        related_parts = field.related.split(".")
+        current_model = res_model
+        for part in related_parts[:-1]:
+            rel_field = self.env[current_model]._fields.get(part)
+            if not rel_field:
+                break
+            if rel_field.type in ("many2one", "many2many", "one2many"):
+                current_model = rel_field.comodel_name
+            else:
+                break
+        final_field = self.env[current_model]._fields.get(related_parts[-1])
+        if final_field and (
+            final_field.company_dependent or "company" in (getattr(final_field, "depends_context", None) or ())
+        ):
+            return "orm"
+        raise ValueError(f"El campo '{field.name}' en '{res_model}' no traza a un campo company_dependent.")
+
+    def _resolve_orm_target(self, res_model, res_id, field_name):
+        """Para campos computed/related, resuelve el modelo, campo y registro
+        reales sobre los que operar con la estrategia ORM.
+
+        Para ``res.config.settings`` con ``related='company_id.xxx'``, opera
+        directamente sobre ``res.company``.
+
+        Para ``product.template`` con ``standard_price`` (computed/inverse
+        delegado a la variante), opera sobre ``product.product``.
+
+        :returns: tupla ``(target_model, target_field_name, target_id)``
+        """
+        field = self.env[res_model]._fields.get(field_name)
+
+        # Estrategia B: auto-detección para res.config.settings related fields
+        if field.related:
+            related_parts = field.related.split(".")
+            if len(related_parts) == 2 and related_parts[0] == "company_id":
+                # related='company_id.xxx' → operar sobre res.company
+                real_field_name = related_parts[1]
+                real_model = "res.company"
+                real_id = self.env.company.id
+                return real_model, real_field_name, real_id
+
+            # Related genérico: seguir la cadena, pero solo a través de many2one.
+            # Atravesar one2many/many2many devolvería un recordset multi y current.id
+            # tomaría un registro arbitrario, lo que llevaría a leer/escribir el target
+            # equivocado. Si la cadena no es traversable, caemos al fallback.
+            record = self.env[res_model].browse(res_id)
+            current = record
+            traversable = True
+            for part in related_parts[:-1]:
+                rel_field = current._fields.get(part)
+                if not rel_field or rel_field.type != "many2one":
+                    traversable = False
+                    break
+                current = current[part]
+            if traversable and current and len(current) == 1:
+                return current._name, related_parts[-1], current.id
+
+        # Computed/inverse: buscar si el campo existe como CD en un modelo
+        # relacionado. Caso emblemático: product.template → product.product.
+        # Verificamos que el res_id sea válido en el modelo destino antes de
+        # recurrir — los IDs no son intercambiables entre modelos, así que solo
+        # tiene sentido si el target apunta a un registro existente con ese id.
+        if hasattr(field, "related_field") and field.related_field:
+            target_model_name = field.related_field.model_name
+            if self.env[target_model_name].browse(res_id).exists():
+                return self._resolve_orm_target(
+                    target_model_name,
+                    res_id,
+                    field.related_field.name,
+                )
+
+        # product.template.standard_price → product.product.standard_price
+        # Con variante única delegamos a la variante para acceder al JSONB real de
+        # product.product (is_specific exacto, valores precisos).
+        # Con múltiples variantes el fallback mantiene el target en product.template:
+        # la lectura devuelve el promedio vía computed y la escritura propaga a todas
+        # las variantes vía _inverse — idéntico al comportamiento nativo de Odoo.
+        if res_model == "product.template":
+            template = self.env["product.template"].browse(res_id)
+            variants = template.product_variant_ids
+            if len(variants) == 1:
+                variant_field = self.env["product.product"]._fields.get(field_name)
+                if variant_field and variant_field.company_dependent:
+                    return "product.product", field_name, variants.id
+
+        # Fallback: usar el modelo/registro original con ORM puro
+        return res_model, field_name, res_id
+
+    # ------------------------------------------------------------------
+    # Lectura ORM (sin JSONB)
+    # ------------------------------------------------------------------
+
+    def _build_row_data_orm(self, field, record, company):  # noqa: C901
+        """Construye el dict de una fila usando lectura ORM pura (with_company).
+
+        No accede a columnas JSONB; lee el valor a través del ORM estándar
+        iterando por compañías con ``record.with_company(company)``.
+        """
+        rec = record.with_company(company)
+        try:
+            raw_val = rec[field.name]
+        except Exception:
+            raw_val = None
+
+        # Obtener el valor de la compañía base (sin context) para comparar
+        base_company = record.company_id if hasattr(record, "company_id") and record.company_id else self.env.company
+        try:
+            base_val = record.with_company(base_company)[field.name]
+        except Exception:
+            base_val = None
+
+        value_id = None
+        display_value = None
+        fallback_value_id = None
+        fallback_display_value = None
+        selection_options = None
+
+        if field.type == "many2one":
+            value_id = raw_val.id if raw_val else None
+            display_value = raw_val.display_name if raw_val else None
+            fallback_value_id = base_val.id if base_val else None
+            fallback_display_value = base_val.display_name if base_val else None
+
+        elif field.type == "selection":
+            selection_options = (
+                list(field.selection)
+                if isinstance(field.selection, list)
+                else [(k, str(v)) for k, v in field._description_selection(rec.env)]
+            )
+            value_id = raw_val
+            for key, label in selection_options:
+                if key == raw_val:
+                    display_value = str(label)
+                    break
+            if display_value is None and raw_val is not None:
+                display_value = str(raw_val)
+            fallback_value_id = base_val
+            for key, label in selection_options:
+                if key == base_val:
+                    fallback_display_value = str(label)
+                    break
+
+        elif field.type in ("float", "integer", "monetary"):
+            val = raw_val if raw_val is not False else None
+            value_id = val
+            display_value = str(val) if val is not None else ""
+            fb = base_val if base_val is not False else None
+            fallback_value_id = fb
+            fallback_display_value = str(fb) if fb is not None else ""
+
+        elif field.type == "boolean":
+            value_id = bool(raw_val) if raw_val is not None else False
+            display_value = str(value_id)
+            fallback_value_id = bool(base_val) if base_val is not None else False
+            fallback_display_value = str(fallback_value_id)
+
+        elif field.type in ("char", "text"):
+            value_id = raw_val
+            display_value = raw_val or ""
+            fallback_value_id = base_val
+            fallback_display_value = base_val or ""
+
+        elif field.type == "date":
+            if hasattr(raw_val, "isoformat"):
+                raw_val = raw_val.isoformat()
+            value_id = raw_val
+            display_value = raw_val
+            fb = base_val
+            if hasattr(fb, "isoformat"):
+                fb = fb.isoformat()
+            fallback_value_id = fb
+            fallback_display_value = fb
+
+        # Para ORM mode, usamos heurística para is_specific: comparamos con
+        # la compañía base. Si difiere, lo consideramos específico.
+        # Para el campo real subyacente, intentamos leer el JSONB si es posible.
+        is_specific = self._check_orm_is_specific(record, field, company)
+
+        row_domain = []
+        if field.type == "many2one":
+            comodel = self.env[field.comodel_name]
+            static_domain = self._get_field_static_domain(field, rec)
+            # Solo aplicar _check_company_domain cuando el comodelo tiene company_id
+            # como campo propio. Si tiene company_ids (One2many) pero no company_id,
+            # el default del ORM produce un dominio con company_id inválido.
+            if "company_id" in comodel._fields:
+                company_domain = Domain(comodel._check_company_domain(company))
+                row_domain = list(static_domain & company_domain)
+            else:
+                row_domain = list(static_domain)
+
+        row = {
+            "company_id": company.id,
+            "company_name": company.name,
+            "is_specific": is_specific,
+            "value_id": value_id,
+            "display_value": display_value,
+            "fallback_value_id": fallback_value_id,
+            "fallback_display_value": fallback_display_value,
+            "domain": row_domain,
+        }
+        if selection_options is not None:
+            row["selection_options"] = selection_options
+        return row
+
+    def _check_orm_is_specific(self, record, field, company):
+        """Determina si el valor del campo es específico para ``company``.
+
+        Intenta resolver al campo CD subyacente para consultar el JSONB real.
+        Si el subyacente no tiene columna JSONB (computed puro sin almacenamiento
+        propio), devuelve ``False`` — el badge Specific/Default no es fiable en
+        ese caso y un falso positivo es más dañino que un falso negativo.
+        """
+        try:
+            target_model, target_field, target_id = self._resolve_orm_target(record._name, record.id, field.name)
+            target_field_obj = self.env[target_model]._fields.get(target_field)
+            if target_field_obj and target_field_obj.company_dependent and target_field_obj.store:
+                raw_json = self._get_raw_json(self.env[target_model]._table, target_field, target_id)
+                return str(company.id) in raw_json
+        except (ValueError, Exception):
+            pass
+
+        # Computed puro sin JSONB: no se puede determinar is_specific sin ambigüedad.
+        return False
+
+    # ------------------------------------------------------------------
+    # Escritura ORM (sin JSONB)
+    # ------------------------------------------------------------------
+
+    def _set_values_orm(self, res_model, res_id, field_name, values_dict):
+        """Escribe valores por compañía usando ORM con with_company.
+
+        Resuelve el target real (ej. res.company para settings, product.product
+        para product.template) y escribe mediante el ORM estándar.
+
+        ``RESET`` se traduce a ``write({field: False})`` — para targets ORM puros
+        (ej. ``res.company`` columnas no-CD) no existe el concepto "remover
+        override" del JSON path, por lo que reset == vaciar al falsy del tipo.
+        Si el target resuelto sí es un campo CD nativo, este método delega al
+        writer JSON donde RESET sí elimina la clave del JSONB.
+
+        Access control: el método público que orquesta este path
+        (``set_company_dependent_values``) chequea ``write`` sobre el
+        ``res_model`` original; acá además chequeamos ``write`` sobre el
+        ``target_model`` resuelto. Las cías del payload se filtran a
+        ``self.env.companies`` para evitar escrituras cross-company por RPC.
+        """
+        target_model, target_field, target_id = self._resolve_orm_target(res_model, res_id, field_name)
+        # Access control sobre el target resuelto (el público ya validó el res_model
+        # original; acá cerramos el segundo modelo cuando el resolver salta de
+        # res.config.settings a res.company / product.product / etc.).
+        self.env["ir.model.access"].check(target_model, "write")
+        _logger.debug(
+            "[CD ORM SET] res_model=%s res_id=%s field=%s → target=(%s, %s, %s) values=%s",
+            res_model,
+            res_id,
+            field_name,
+            target_model,
+            target_field,
+            target_id,
+            values_dict,
+        )
+
+        target_field_obj = self.env[target_model]._fields.get(target_field)
+        record = self.env[target_model].browse(target_id)
+
+        # Si el target resuelto es un campo CD nativo, delegamos al writer
+        # JSON original que tiene mejor manejo de fallbacks y sanitización.
+        if target_field_obj and target_field_obj.company_dependent and target_field_obj.store:
+            _logger.debug("[CD ORM SET] delegating to JSON writer (target field is CD native)")
+            return self.set_company_dependent_values(target_model, target_id, target_field, values_dict)
+
+        # Filtrar a las cías accesibles para el usuario: un RPC malicioso podría
+        # incluir IDs fuera de env.companies; los descartamos antes de escribir.
+        accessible_ids = set(self.env.companies.ids)
+
+        # Escritura ORM pura
+        saved = []
+        skipped = []
+
+        for company_id_str, value in values_dict.items():
+            company_id = int(company_id_str)
+            company = self.env["res.company"].browse(company_id)
+            if company_id not in accessible_ids:
+                # Defensive skip: a malicious RPC payload listed a company the
+                # caller cannot access. Info-level — the structured `skipped`
+                # list below is what callers should consume; a WARNING here
+                # breaks runbot's strict-warning policy on the Adhoc CI.
+                _logger.info(
+                    "_set_values_orm: skip company id=%s — not in env.companies",
+                    company_id,
+                )
+                skipped.append({"id": company_id, "name": company.name or "", "reason": "no access to company"})
+                continue
+
+            try:
+                with self.env.cr.savepoint():
+                    # Para res.company cada compañía ES un registro distinto;
+                    # with_company no cambia el record.id, solo el contexto.
+                    if target_model == "res.company":
+                        rec = self.env["res.company"].browse(company_id)
+                    else:
+                        rec = record.with_company(company)
+                    write_value = False if value == "RESET" else value
+                    before = rec[target_field]
+                    rec.write({target_field: write_value})
+                    after = rec[target_field]
+                    _logger.debug(
+                        "[CD ORM SET] wrote company=%s rec=%s.%s=%s (before=%r after=%r)",
+                        company.name,
+                        rec._name,
+                        rec.id,
+                        write_value,
+                        before,
+                        after,
+                    )
+                saved.append(company_id)
+            except (ValidationError, UserError) as exc:
+                reason = exc.args[0] if exc.args else str(exc)
+                if hasattr(reason, "__html__"):
+                    reason = str(reason)
+                _logger.warning(
+                    "set_values_orm: skip company %s (id=%s) — %s",
+                    company.name,
+                    company_id,
+                    reason,
+                )
+                skipped.append({"id": company_id, "name": company.name, "reason": str(reason)})
+
+        return {"saved": saved, "skipped": skipped}
+
+    # ------------------------------------------------------------------
     # API pública (llamada desde el frontend via RPC)
     # ------------------------------------------------------------------
 
@@ -272,8 +636,11 @@ class BaseCompanyDependent(models.AbstractModel):
         if field.type == "many2one":
             comodel = self.env[field.comodel_name]
             static_domain = self._get_field_static_domain(field, model_obj)
-            company_domain = Domain(comodel._check_company_domain(company))
-            row_domain = list(static_domain & company_domain)
+            if "company_id" in comodel._fields:
+                company_domain = Domain(comodel._check_company_domain(company))
+                row_domain = list(static_domain & company_domain)
+            else:
+                row_domain = list(static_domain)
 
         row = {
             "company_id": company.id,
@@ -290,7 +657,7 @@ class BaseCompanyDependent(models.AbstractModel):
         return row
 
     @api.model
-    def get_company_dependent_values(self, res_model, res_id, field_name):
+    def get_company_dependent_values(self, res_model, res_id, field_name, mode=None):
         """Retorna los valores por compañía para un campo company_dependent.
 
         Solo se incluyen las compañías a las que el usuario tiene acceso
@@ -299,12 +666,23 @@ class BaseCompanyDependent(models.AbstractModel):
         :param res_model: Nombre técnico del modelo (ej. 'product.category').
         :param res_id: ID del registro.
         :param field_name: Nombre técnico del campo.
+        :param mode: ``'json'``, ``'orm'`` o ``None`` (auto-detectar).
         :returns: dict con claves:
             - ``values``: lista de dicts por compañía con datos de jerarquía.
             - ``field_type``: 'many2one', 'selection', 'float', 'integer', etc.
             - ``comodel_name``: modelo del Many2one (solo si aplica).
             - ``selection_options``: lista [(key, label)] (solo si selection).
         """
+        if mode is None:
+            mode = self._detect_field_strategy(res_model, field_name)
+
+        if mode == "orm":
+            return self._get_values_orm(res_model, res_id, field_name)
+
+        return self._get_values_json(res_model, res_id, field_name)
+
+    def _get_values_json(self, res_model, res_id, field_name):
+        """Implementación JSONB directa del getter de valores por compañía."""
         self.env["ir.model.access"].check(res_model, "read")
         model_obj = self.env[res_model]
         model_obj.browse(res_id).check_access("read")
@@ -353,120 +731,85 @@ class BaseCompanyDependent(models.AbstractModel):
             "selection_options": selection_options,
         }
 
-    @api.model
-    def copy_value_to_children(self, res_model, res_id, field_name, source_company_id):
-        """Propaga el valor del campo en ``source_company_id`` a todos sus hijos
-        accesibles (recursivo hasta 3 niveles).
+    def _get_values_orm(self, res_model, res_id, field_name):
+        """Implementación ORM pura del getter de valores por compañía.
 
-        Verifica que el usuario tenga acceso de escritura al modelo y que las
-        compañías destino estén en ``self.env.companies``.
-
-        :param source_company_id: ID de la compañía cuyo valor se va a propagar.
-        :returns: dict con dos claves: ``updated`` (lista de company_ids actualizados)
-                  y ``skipped`` (lista de company_ids omitidos).
+        Resuelve el target real (ej. ``res.company`` para settings,
+        ``product.product`` para template) y lee valores con ``with_company``.
         """
-        self.env["ir.model.access"].check(res_model, "write")
+        self.env["ir.model.access"].check(res_model, "read")
         model_obj = self.env[res_model]
+        model_obj.browse(res_id).check_access("read")
         field = model_obj._fields.get(field_name)
+        if not field:
+            raise ValueError(f"El campo '{field_name}' no existe en '{res_model}'.")
 
-        if not field or not field.company_dependent:
-            raise ValueError(f"El campo '{field_name}' en '{res_model}' no es company_dependent.")
+        # Resolver target real para lectura
+        target_model, target_field, target_id = self._resolve_orm_target(res_model, res_id, field_name)
+        _logger.debug(
+            "[CD ORM GET] res_model=%s res_id=%s field=%s → target=(%s, %s, %s)",
+            res_model,
+            res_id,
+            field_name,
+            target_model,
+            target_field,
+            target_id,
+        )
+        target_field_obj = self.env[target_model]._fields.get(target_field)
+        target_record = self.env[target_model].browse(target_id)
 
-        accessible_ids = set(self.env.companies.ids)
-        if source_company_id not in accessible_ids:
-            raise ValueError("No tiene acceso a la compañía origen.")
+        # Si el target tiene JSONB nativo, delegamos la lectura al path JSON
+        if target_field_obj and target_field_obj.company_dependent and target_field_obj.store:
+            return self._get_values_json(target_model, target_id, target_field)
 
-        raw_json = self._get_raw_json(model_obj._table, field_name, res_id)
-        source_key = str(source_company_id)
-        source_value = raw_json.get(source_key)  # puede ser None (no especificado)
+        # Lectura ORM pura
+        hierarchy = {h["id"]: h for h in self._get_accessible_companies_hierarchy()}
 
-        # Obtenemos el valor real que se va a propagar: si hay clave → ese valor;
-        # si no hay clave → el fallback resuelto para esa compañía.
-        if source_key in raw_json:
-            value_to_copy = source_value
-        else:
-            source_company = self.env["res.company"].browse(source_company_id)
-            model_with_company = model_obj.with_company(source_company)
-            try:
-                fallback_rec = field.get_company_dependent_fallback(model_with_company)
-                fv = field.convert_to_write(fallback_rec, model_with_company)
-                # Convertir a formato de columna para escribir en el JSON
-                value_to_copy = field.convert_to_column(fv, model_with_company)
-            except Exception:
-                value_to_copy = None
-
-        # Recorrer hijos recursivamente (máx 3 niveles desde el padre original)
-        def _get_all_descendants(company, depth=0):
-            if depth >= 2:  # profundidad máxima desde el primer hijo (0-indexed)
-                return []
-            descendants = []
-            for child in company.child_ids:
-                if child.id in accessible_ids:
-                    descendants.append(child)
-                    descendants.extend(_get_all_descendants(child, depth + 1))
-            return descendants
-
-        source_company_rec = self.env["res.company"].browse(source_company_id)
-        targets = _get_all_descendants(source_company_rec)
-
-        if not targets:
-            return {"updated": [], "skipped": []}
-
-        record = model_obj.browse(res_id)
-
-        # Sanitize para many2one
-        if field.type == "many2one":
-            current_json = self._get_raw_json(model_obj._table, field_name, res_id)
-            sanitized = {k: (None if v is False else v) for k, v in current_json.items()}
-            if sanitized != current_json:
-                self._write_raw_json(model_obj._table, field_name, res_id, sanitized)
-                record.invalidate_recordset([field_name])
-
-        updated = []
-        skipped = []
-        for target in targets:
-            write_value = value_to_copy
-            # Para Many2one, el value_to_copy almacenado en JSONB es el ID (int/None)
-            # Necesitamos pasarlo al ORM en el formato correcto para write().
-            if field.type == "many2one":
-                write_val_orm = int(value_to_copy) if value_to_copy else False
+        values = []
+        for company in self.env.companies:
+            # Para res.company cada compañía es su propio registro; no se puede
+            # usar with_company sobre un registro fijo porque los campos normales
+            # (no company_dependent) no varían por contexto sino por record.id.
+            if target_model == "res.company":
+                record_for_company = self.env["res.company"].browse(company.id)
             else:
-                write_val_orm = value_to_copy
+                record_for_company = target_record
+            _logger.debug(
+                "[CD ORM GET] reading for company=%s record=%s.%s → %r",
+                company.name,
+                record_for_company._name,
+                record_for_company.id,
+                record_for_company.with_company(company)[target_field],
+            )
+            row = self._build_row_data_orm(target_field_obj, record_for_company, company)
+            hier = hierarchy.get(company.id, {})
+            row["parent_id"] = hier.get("parent_id")
+            row["level"] = hier.get("level", 1)
+            row["has_children"] = hier.get("has_children", False)
+            row["child_ids"] = hier.get("child_ids", [])
+            values.append(row)
 
-            # Usamos un savepoint por compañía destino para que un error de
-            # company_crossover en una hija no aborte el resto del lote.
-            try:
-                with self.env.cr.savepoint():
-                    record_with_company = record.with_company(target)
-                    record_with_company.write({field_name: write_val_orm})
+        values.sort(key=lambda r: (r["level"], r.get("parent_id") or 0, r["company_id"]))
 
-                    # Forzar la clave en el JSON si el valor coincide con el fallback
-                    # (el ORM lo descartaría en ese caso)
-                    current_json = self._get_raw_json(model_obj._table, field_name, res_id)
-                    target_key = str(target.id)
-                    if target_key not in current_json:
-                        current_json[target_key] = write_value
-                        self._write_raw_json(model_obj._table, field_name, res_id, current_json)
-                        record.invalidate_recordset([field_name])
+        comodel_name = target_field_obj.comodel_name if target_field_obj.type == "many2one" else None
 
-                updated.append(target.id)
-            except (ValidationError, UserError) as exc:
-                # Registrar la falla sin interrumpir el resto del lote.
-                reason = exc.args[0] if exc.args else str(exc)
-                # Limpiar etiquetas HTML básicas para el mensaje
-                if hasattr(reason, "__html__"):
-                    reason = str(reason)
-                _logger.warning(
-                    "copy_value_to_children: skip %s (id=%s) — %s",
-                    target.name,
-                    target.id,
-                    reason,
-                )
-                skipped.append({"id": target.id, "name": target.name, "reason": str(reason)})
+        selection_options = None
+        if target_field_obj.type == "selection":
+            selection_options = (
+                list(target_field_obj.selection)
+                if isinstance(target_field_obj.selection, list)
+                else [(k, str(v)) for k, v in target_field_obj._description_selection(model_obj.env)]
+            )
+            for r in values:
+                r.pop("selection_options", None)
 
-        return {"updated": updated, "skipped": skipped}
+        return {
+            "values": values,
+            "field_type": target_field_obj.type,
+            "comodel_name": comodel_name,
+            "selection_options": selection_options,
+        }
 
-    @api.model
     def _get_field_domain_for_company(self, res_model, field_name, company_id):
         """Devuelve el domain efectivo para un campo Many2one company_dependent,
         combinando el domain estático del campo con el domain de compañía.
@@ -488,13 +831,15 @@ class BaseCompanyDependent(models.AbstractModel):
 
         # _get_field_static_domain maneja dominios string, list y callable
         static_domain = self._get_field_static_domain(field, model_obj)
-        company_domain = Domain(comodel._check_company_domain(company))
-
-        effective = static_domain & company_domain
+        if "company_id" in comodel._fields:
+            company_domain = Domain(comodel._check_company_domain(company))
+            effective = static_domain & company_domain
+        else:
+            effective = static_domain
         return list(effective)
 
     @api.model
-    def set_company_dependent_values(self, res_model, res_id, field_name, values_dict):
+    def set_company_dependent_values(self, res_model, res_id, field_name, values_dict, mode=None):
         """Guarda valores por compañía para un campo company_dependent.
 
         Para valores explícitos (IDs o False) se usa el ORM con ``with_company``
@@ -509,10 +854,24 @@ class BaseCompanyDependent(models.AbstractModel):
             - Un ID de registro (Many2one).
             - ``False``: guarda la clave como ``false`` en el JSON (vacío explícito).
             - ``"RESET"``: **elimina** la clave del JSON (restaura al fallback).
+        :param mode: ``'json'``, ``'orm'`` o ``None`` (auto-detectar).
         :returns: dict con dos claves: ``saved`` (lista de company_ids guardados)
                   y ``skipped`` (lista de dicts {id, name, reason} que fallaron).
         """
+        if mode is None:
+            try:
+                mode = self._detect_field_strategy(res_model, field_name)
+            except ValueError:
+                mode = "json"
+
+        # Access control aplicado a ambos paths (json y orm).  El path orm,
+        # además, valida write sobre el target_model resuelto dentro de
+        # _set_values_orm — la cadena res.config.settings → res.company
+        # cruza el chequeo dos veces.
         self.env["ir.model.access"].check(res_model, "write")
+
+        if mode == "orm":
+            return self._set_values_orm(res_model, res_id, field_name, values_dict)
         model_obj = self.env[res_model]
         field = model_obj._fields.get(field_name)
 
@@ -590,25 +949,39 @@ class BaseCompanyDependent(models.AbstractModel):
         valor explícito en el JSON.
 
         Usa una sola query SQL para no generar N+1 consultas.
+        También detecta campos ORM-mode (computed con depends_context('company'))
+        y los incluye usando heurística.
         """
         self.env["ir.model.access"].check(res_model, "read")
         model_obj = self.env[res_model]
         company_key = str(self.env.company.id)
+        result = {}
 
+        # Campos CD nativos (JSONB)
         cd_fields = [name for name, f in model_obj._fields.items() if f.company_dependent and f.store]
-        if not cd_fields:
-            return {}
+        if cd_fields:
+            self.env.cr.execute(
+                sql.SQL("SELECT {cols} FROM {table} WHERE id = %s").format(
+                    cols=sql.SQL(", ").join(sql.Identifier(f) for f in cd_fields),
+                    table=sql.Identifier(model_obj._table),
+                ),
+                (res_id,),
+            )
+            row = self.env.cr.fetchone()
+            if row:
+                result.update({field_name: (company_key in (row[i] or {})) for i, field_name in enumerate(cd_fields)})
 
-        # Una sola SELECT para todos los campos company_dependent
-        self.env.cr.execute(
-            sql.SQL("SELECT {cols} FROM {table} WHERE id = %s").format(
-                cols=sql.SQL(", ").join(sql.Identifier(f) for f in cd_fields),
-                table=sql.Identifier(model_obj._table),
-            ),
-            (res_id,),
-        )
-        row = self.env.cr.fetchone()
-        if not row:
-            return {}
+        # Campos ORM-mode: computed con depends_context('company')
+        for name, f in model_obj._fields.items():
+            if name in result:
+                continue
+            depends_ctx = getattr(f, "depends_context", None) or ()
+            if "company" not in depends_ctx:
+                continue
+            try:
+                record = model_obj.browse(res_id)
+                result[name] = self._check_orm_is_specific(record, f, self.env.company)
+            except Exception:
+                pass
 
-        return {field_name: (company_key in (row[i] or {})) for i, field_name in enumerate(cd_fields)}
+        return result

--- a/base_company_dependent/spec
+++ b/base_company_dependent/spec
@@ -1,0 +1,35 @@
+Contexto del Problema:
+Actualmente tenemos un widget funcional para gestionar campos company_dependent. Este widget trabaja directamente sobre la estructura de datos (JSON) cuando el campo existe físicamente en el modelo. Sin embargo, basándonos en una nueva necesidad técnica, debemos dar soporte a:
+
+Campos Computed/Inverse: (Ej: standard_price en el template, cuyo valor real reside en las variantes).
+
+Campos Related: (Ej: Los campos en res.config.settings que apuntan a configuraciones de la compañía).
+
+En estos casos, no hay una columna JSON para manipular. Debemos usar obligatoriamente los Getters y Setters del ORM de Odoo mediante el contexto with_company.
+
+Tu Tarea: Fase de Análisis (CRÍTICO):
+Antes de generar código, analiza la estructura del widget actual que tienes en contexto y decide cuál de estos dos caminos es más limpio, mantenible y eficiente en Odoo:
+
+Opción A (Adaptación/Polimorfismo): Modificar el widget actual para que detecte si el campo es un company_dependent nativo (JSON) o un campo "virtual" (Related/Computed). Debería abstraer la capa de persistencia para llamar a diferentes métodos RPC según el caso.
+
+Opción B (Nuevo Widget Especializado): Crear un segundo widget (ej. company_dependent_orm) que reutilice la UI del primero pero que implemente una lógica de comunicación con el servidor totalmente distinta, basada en with_company e iteración de IDs de compañía.
+
+Requerimientos para la implementación (según el camino elegido):
+
+Capa de Datos (Python): Independiente del camino, necesitamos métodos en el backend que permitan al widget obtener y setear valores iterando por compañías (for company in companies: val = record.with_company(company).field_name).
+
+Capa de UI (OWL):
+
+El widget debe funcionar en formularios estándar y ser compatible con la vista de res.config.settings.
+
+En el video de referencia se menciona que en res.config.settings el icono del edificio se renderiza de forma especial. Debes proponer cómo integrar nuestro disparador (el botón que abre el popup) en esos nodos, considerando que suelen ser campos related.
+
+Lógica de Negocio: El widget debe ser capaz de manejar el "getter" y el "setter" de forma transparente para el usuario, aunque por detrás esté disparando métodos _inverse o escribiendo en tablas relacionadas.
+
+Resultado Esperado:
+
+Diagnóstico: Dime qué opción eliges (A o B) y por qué, basándote en la complejidad del código actual.
+
+Código: Entrégame la solución completa (Python, JS, XML) para que el widget sea funcional en el campo standard_price de productos y en los settings de Odoo.
+
+Estrategia de Vistas: Explica cómo debemos heredar o modificar las vistas para que el widget aparezca en los related de los settings donde Odoo ya pone el icono del edificio por defecto.

--- a/base_company_dependent/static/src/company_dependent.css
+++ b/base_company_dependent/static/src/company_dependent.css
@@ -89,7 +89,7 @@
 
 /* ── Diálogo general ─────────────────────────────────────────────────────── */
 .o_cd_dialog .table th {
-    background-color: var(--bs-light, #f8f9fa);
+    background-color: var(--bs-tertiary-bg, #f8f9fa);
     font-weight: 600;
     font-size: 0.85rem;
 }
@@ -162,12 +162,14 @@
 }
 
 /* Subtle background tinting by hierarchy depth.
- * !important needed to override Bootstrap's CSS-variable-based table bg. */
+ * Uses --bs-emphasis-color-rgb (dark-aware in Bootstrap 5.3+) so the tint
+ * is visible in both light and dark themes. !important needed to override
+ * Bootstrap's CSS-variable-based table bg. */
 .o_cd_depth_1 > td {
-    background-color: rgba(0, 0, 0, 0.013) !important;
+    background-color: rgba(var(--bs-emphasis-color-rgb), 0.025) !important;
 }
 .o_cd_depth_2 > td {
-    background-color: rgba(0, 0, 0, 0.025) !important;
+    background-color: rgba(var(--bs-emphasis-color-rgb), 0.05) !important;
 }
 /* Row hover has higher selector specificity (2 classes + pseudo) than depth
  * (1 class), so hover always wins on mouse-over — no extra rule needed. */
@@ -212,16 +214,16 @@
 }
 
 /* ── Estilo de filas por nivel ───────────────────────────────────────────── */
+/* Los backgrounds vienen del tinting `.o_cd_depth_N > td` arriba, basado en
+ * --bs-emphasis-color-rgb (dark-aware). Acá solo definimos tipografía. */
 
 /* Nivel 0 – Compañía raíz */
 .o_cd_depth_0 {
-    background-color: var(--bs-white, #fff);
     font-weight: 600;
 }
 
 /* Nivel 1 – Compañía hija */
 .o_cd_depth_1 {
-    background-color: var(--bs-gray-100, #f8f9fa);
     font-weight: 400;
 }
 
@@ -231,7 +233,6 @@
 
 /* Nivel 2 – Compañía nieta */
 .o_cd_depth_2 {
-    background-color: var(--bs-gray-200, #e9ecef);
     font-weight: 400;
     font-size: 0.9rem;
 }
@@ -253,9 +254,10 @@
 /* Hover sutil: intentionally uses background-color, NOT filter/opacity/transform.
  * Those CSS properties create a new stacking context which changes the
  * containing block for position:fixed children (the AutoComplete dropdown).
- * That would cause the dropdown to shift to wrong coordinates on hover. */
+ * That would cause the dropdown to shift to wrong coordinates on hover.
+ * Uses --bs-emphasis-color-rgb so contrast holds in both themes. */
 .o_cd_row:hover > td {
-    background-color: rgba(0, 0, 0, 0.035) !important;
+    background-color: rgba(var(--bs-emphasis-color-rgb), 0.06) !important;
 }
 
 /* ── Botón Copy ──────────────────────────────────────────────────────────── */

--- a/base_company_dependent/static/src/company_dependent_button.js
+++ b/base_company_dependent/static/src/company_dependent_button.js
@@ -2,7 +2,7 @@
 
 import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
-import { useOwnedDialogs } from "@web/core/utils/hooks";
+import { useOwnedDialogs, useService } from "@web/core/utils/hooks";
 import { CompanyDependentDialog } from "./company_dependent_dialog";
 
 /**
@@ -22,16 +22,18 @@ import { CompanyDependentDialog } from "./company_dependent_dialog";
 export class CompanyDependentButton extends Component {
     static template = "base_company_dependent.CompanyDependentButton";
     static props = {
-        fieldName: { type: String },
+        fieldName: { type: String, optional: true },
         fieldString: { type: String },
         required: { type: Boolean },
         record: { type: Object },
         isSpecific: { validate: (v) => v === null || typeof v === "boolean" },
         onSaved: { type: Function, optional: true },
+        mode: { validate: (v) => v == null || typeof v === "string", optional: true },
     };
 
     setup() {
         this.addDialog = useOwnedDialogs();
+        this.notification = useService("notification");
     }
 
     get title() {
@@ -44,6 +46,13 @@ export class CompanyDependentButton extends Component {
     }
 
     async onClick() {
+        if (!this.props.fieldName) {
+            this.notification.add(
+                _t("These values are company-specific. Switch company to see or edit values for other companies."),
+                { type: "info" },
+            );
+            return;
+        }
         // Cerrar cualquier AutoComplete/dropdown abierto en el formulario antes
         // de guardar, para evitar que el dropdown del campo aparezca detrás del diálogo.
         if (document.activeElement && document.activeElement !== document.body) {
@@ -61,6 +70,7 @@ export class CompanyDependentButton extends Component {
             required: this.props.required,
             resId,
             resModel,
+            mode: this.props.mode || null,
             onSaved: async () => {
                 await this.props.record.load();
                 if (this.props.onSaved) {

--- a/base_company_dependent/static/src/company_dependent_dialog.js
+++ b/base_company_dependent/static/src/company_dependent_dialog.js
@@ -29,6 +29,7 @@ export class CompanyDependentDialog extends Component {
         resModel: { type: String },
         onSaved: { type: Function },
         close: { type: Function },
+        mode: { validate: (v) => v === null || v === "json" || v === "orm", optional: true },
     };
 
     setup() {
@@ -131,11 +132,12 @@ export class CompanyDependentDialog extends Component {
     // ---------------------------------------------------------------
 
     async _loadValues() {
-        const { resModel, resId, fieldName } = this.props;
+        const { resModel, resId, fieldName, mode } = this.props;
         const result = await this.orm.call(
             "base.company.dependent",
             "get_company_dependent_values",
             [resModel, resId, fieldName],
+            { mode: mode || null },
         );
         this.state.rows = result.values.map((row) => ({ ...row }));
         this.state.fieldType = result.field_type;
@@ -435,6 +437,7 @@ export class CompanyDependentDialog extends Component {
             "base.company.dependent",
             "set_company_dependent_values",
             [this.props.resModel, this.props.resId, this.props.fieldName, valuesDict],
+            { mode: this.props.mode || null },
         );
 
         this.cdService.invalidate(this.props.resModel, this.props.resId);

--- a/base_company_dependent/static/src/fields_patch.js
+++ b/base_company_dependent/static/src/fields_patch.js
@@ -47,10 +47,25 @@ function makeCDPatch() {
         },
 
         /**
-         * True when the field is marked as company_dependent in the model.
+         * True when the field is marked as company_dependent in the model,
+         * OR when explicitly opted-in via field options.
          */
         get isCompanyDependent() {
-            return this.props.record?.fields?.[this.props.name]?.company_dependent === true;
+            const fieldDef = this.props.record?.fields?.[this.props.name];
+            if (fieldDef?.company_dependent === true) return true;
+            // Explicit opt-in via options="{'company_dependent_mode': 'orm'}"
+            const options = this.props.options || {};
+            return options.company_dependent_mode === "orm";
+        },
+
+        /**
+         * Returns the persistence mode for the company_dependent dialog.
+         * 'orm' for computed/related fields, 'json' for native JSONB fields.
+         */
+        get cdMode() {
+            const options = this.props.options || {};
+            if (options.company_dependent_mode === "orm") return "orm";
+            return null; // let backend auto-detect
         },
 
         /**

--- a/base_company_dependent/static/src/settings_patch.js
+++ b/base_company_dependent/static/src/settings_patch.js
@@ -1,0 +1,139 @@
+/** @odoo-module **/
+/**
+ * Patches the Setting component used in res.config.settings views to replace
+ * the static fa-building-o icon with an interactive CompanyDependentButton.
+ *
+ * This allows users to click the building icon in settings and see/edit
+ * values per company, just like on regular form views.
+ */
+
+import { onMounted, onWillStart, useState } from "@odoo/owl";
+import { user } from "@web/core/user";
+import { useService } from "@web/core/utils/hooks";
+import { patch } from "@web/core/utils/patch";
+import { Setting } from "@web/views/form/setting/setting";
+import { SearchableSetting } from "@web/webclient/settings_form_view/settings/searchable_setting";
+import { CompanyDependentButton } from "./company_dependent_button";
+
+Setting.components = { ...Setting.components, CompanyDependentButton };
+SearchableSetting.components = { ...SearchableSetting.components, CompanyDependentButton };
+
+patch(Setting.prototype, {
+    setup() {
+        super.setup();
+        this._cdService = useService("company_dependent");
+        this._cdState = useState({ isSpecific: null, discoveredField: null });
+        // Upstream's compiler sets `companyDependent` to `true` (boolean) when
+        // the <setting> has `company_dependent="1"`, otherwise to the literal
+        // string `"false"` (which is truthy in JS). Compare strictly to `true`
+        // so the meta lookup/DOM discovery only runs on opted-in settings.
+        if (this.props.companyDependent === true) {
+            if (this.props.fieldName) {
+                onWillStart(() => this._loadCDMeta());
+            } else {
+                // No fieldName from compiler: discover from DOM after mount
+                onMounted(() => this._discoverFieldFromDOM());
+            }
+        }
+    },
+
+    /**
+     * Override: suppress the static icon when we can show the interactive
+     * button instead.
+     */
+    get displayCompanyDependentIcon() {
+        if (this.displayCompanyDependentButton) {
+            return false;
+        }
+        return super.displayCompanyDependentIcon;
+    },
+
+    /**
+     * Whether to show the interactive CompanyDependentButton.
+     *
+     * Visible when company_dependent="1" is set on the <setting>, there is
+     * more than one accessible company, and we can identify a target field —
+     * either via the compiler-set labelString/fieldName, or via a field
+     * discovered from the rendered DOM (covers settings where the first
+     * child is not a <field>, e.g. document_layout_setting, default_taxes).
+     */
+    get displayCompanyDependentButton() {
+        if (this.props.companyDependent !== true) return false;
+        if (!this.props.record || user.allowedCompanies.length <= 1) return false;
+        return Boolean(this.labelString || this.cdFieldName);
+    },
+
+    /**
+     * Effective field name: from compiler prop or discovered from DOM.
+     */
+    get cdFieldName() {
+        return this.props.fieldName || this._cdState.discoveredField || "";
+    },
+
+    /**
+     * The field's label string.
+     *
+     * Falls back to the discovered field's string when the setting itself
+     * has no labelString (settings whose first child is a wrapper div).
+     */
+    get cdFieldString() {
+        if (this.labelString) return this.labelString;
+        const fn = this.cdFieldName;
+        const fieldDef = fn ? this.props.record?.fields?.[fn] : null;
+        return fieldDef?.string || fn || "";
+    },
+
+    /**
+     * Whether the field is required.
+     */
+    get cdFieldRequired() {
+        const fn = this.cdFieldName;
+        if (!this.props.record || !fn) return false;
+        try {
+            return this.props.record._isRequired(fn);
+        } catch {
+            return false;
+        }
+    },
+
+    /**
+     * Discover the first visible field widget name inside the setting DOM.
+     * Called onMounted when the compiler didn't set a fieldName (cases where
+     * the first child of <setting> is a wrapper div, not a <field>).
+     *
+     * Iterates over all .o_field_widget[name] descendants and picks the first
+     * one that is actually rendered (offsetParent != null skips fields hidden
+     * by `invisible=...` or by `groups=...` the user doesn't belong to).
+     *
+     * Uses the public `settingRef` only (set by upstream's Setting). If a
+     * future Odoo refactors removes settingRef the discovery silently
+     * degrades to "no button" — better than reaching into OWL's private
+     * `__owl__.bdom.el` and breaking on every minor upgrade.
+     */
+    _discoverFieldFromDOM() {
+        const el = this.settingRef?.el;
+        if (!el) return;
+        const widgets = el.querySelectorAll(".o_field_widget[name]");
+        for (const widget of widgets) {
+            if (widget.offsetParent !== null) {
+                this._cdState.discoveredField = widget.getAttribute("name");
+                this._loadCDMeta();
+                return;
+            }
+        }
+    },
+
+    async _loadCDMeta() {
+        const fn = this.cdFieldName;
+        if (!fn) return;
+        const { resModel, resId } = this.props.record;
+        if (!resId) return;
+        const meta = await this._cdService.getMetaForRecord(resModel, resId);
+        this._cdState.isSpecific = meta[fn] ?? false;
+    },
+
+    async _onCDSaved() {
+        await this.props.record.load();
+        await this._loadCDMeta();
+    },
+});

--- a/base_company_dependent/static/src/settings_patch.xml
+++ b/base_company_dependent/static/src/settings_patch.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <!-- Replace the static building icon with an interactive CompanyDependentButton.
+         Target SearchableSetting (the primary copy used in res.config.settings views)
+         because extensions on web.Setting don't propagate to primary copies from
+         earlier-loaded modules due to OWL's block-ordering filter. -->
+    <t t-inherit="web.SearchableSetting" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='displayCompanyDependentIcon']" position="replace">
+            <t t-if="displayCompanyDependentButton">
+                <CompanyDependentButton
+                    fieldName="cdFieldName"
+                    fieldString="cdFieldString"
+                    required="cdFieldRequired"
+                    record="props.record"
+                    isSpecific="_cdState.isSpecific"
+                    mode="'orm'"
+                    onSaved="() => this._onCDSaved()"
+                />
+            </t>
+            <t t-elif="displayCompanyDependentIcon">
+                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
+            </t>
+        </xpath>
+    </t>
+
+</templates>

--- a/base_company_dependent/static/src/templates.xml
+++ b/base_company_dependent/static/src/templates.xml
@@ -29,6 +29,7 @@
                     required="props.record._isRequired(props.name)"
                     record="props.record"
                     isSpecific="_cdState.isSpecific"
+                    mode="cdMode"
                     onSaved="() => this._loadCDMeta()"
                 />
             </div>
@@ -86,6 +87,7 @@
                     required="props.record._isRequired(props.name)"
                     record="props.record"
                     isSpecific="_cdState.isSpecific"
+                    mode="cdMode"
                     onSaved="() => this._loadCDMeta()"
                 />
             </div>
@@ -147,6 +149,7 @@
                     required="props.record._isRequired(props.name)"
                     record="props.record"
                     isSpecific="_cdState.isSpecific"
+                    mode="cdMode"
                     onSaved="() => this._loadCDMeta()"
                 />
             </div>
@@ -194,6 +197,7 @@
                     required="props.record._isRequired(props.name)"
                     record="props.record"
                     isSpecific="_cdState.isSpecific"
+                    mode="cdMode"
                     onSaved="() => this._loadCDMeta()"
                 />
             </div>
@@ -238,6 +242,7 @@
                     required="props.record._isRequired(props.name)"
                     record="props.record"
                     isSpecific="_cdState.isSpecific"
+                    mode="cdMode"
                     onSaved="() => this._loadCDMeta()"
                 />
             </div>
@@ -272,6 +277,7 @@
                     required="props.record._isRequired(props.name)"
                     record="props.record"
                     isSpecific="_cdState.isSpecific"
+                    mode="cdMode"
                     onSaved="() => this._loadCDMeta()"
                 />
             </div>
@@ -301,7 +307,8 @@
                 required="props.record._isRequired(props.name)"
                 record="props.record"
                 isSpecific="_cdState.isSpecific"
-                onSaved="() => this._loadCDMeta()"
+                mode="cdMode"
+                    onSaved="() => this._loadCDMeta()"
             />
         </xpath>
     </t>
@@ -329,7 +336,8 @@
                 required="props.record._isRequired(props.name)"
                 record="props.record"
                 isSpecific="_cdState.isSpecific"
-                onSaved="() => this._loadCDMeta()"
+                mode="cdMode"
+                    onSaved="() => this._loadCDMeta()"
             />
         </div>
     </t>

--- a/base_company_dependent/tests/test_base_company_dependent.py
+++ b/base_company_dependent/tests/test_base_company_dependent.py
@@ -413,3 +413,166 @@ class TestBaseCompanyDependent(TransactionCase):
     def test_access_check_on_meta(self):
         """get_company_dependent_meta verifica acceso de lectura al modelo."""
         self.helper.get_company_dependent_meta("res.partner", self.partner.id)
+
+    # ------------------------------------------------------------------
+    # ORM mode: res.config.settings related to company_id.*
+    # ------------------------------------------------------------------
+
+    def _find_settings_related_field(self):
+        """Pick a field on res.config.settings related to a stored, non-CD
+        field on res.company. Used by the ORM-mode tests; returns
+        ``(settings_field_name, company_field_name)`` or ``None`` if none
+        is installed (in which case the caller should skip)."""
+        Settings = self.env["res.config.settings"]
+        Company = self.env["res.company"]
+        for fname, field in Settings._fields.items():
+            if not field.related or not field.related.startswith("company_id."):
+                continue
+            parts = field.related.split(".")
+            if len(parts) != 2:
+                continue
+            company_field = Company._fields.get(parts[1])
+            if not company_field or not company_field.store:
+                continue
+            return fname, parts[1]
+        return None
+
+    def test_resolve_orm_target_settings_related(self):
+        """_resolve_orm_target maps `related='company_id.foo'` to res.company.foo
+        for the current company — the path the widget uses on Setting views."""
+        pair = self._find_settings_related_field()
+        if not pair:
+            self.skipTest("No suitable related field on res.config.settings")
+        settings_field, company_field = pair
+        settings = self.env["res.config.settings"].create({})
+        target_model, target_field, target_id = self.helper._resolve_orm_target(
+            "res.config.settings", settings.id, settings_field
+        )
+        self.assertEqual(target_model, "res.company")
+        self.assertEqual(target_field, company_field)
+        self.assertEqual(target_id, self.env.company.id)
+
+    def test_set_values_orm_res_company_branch(self):
+        """ORM-mode setter on a res.company target writes each company's own
+        record directly (each company is its own record) — this is the branch
+        the widget uses for res.config.settings related fields whose target
+        is a plain (non-CD, non-related) column on res.company.
+
+        Picks any stored boolean field on res.company that is not related
+        and not computed, so the test is independent of which add-ons are
+        installed.
+        """
+        Company = self.env["res.company"]
+        bool_field = next(
+            (
+                fname
+                for fname, f in Company._fields.items()
+                if f.type == "boolean" and f.store and not f.related and not f.compute and fname not in ("active",)
+            ),
+            None,
+        )
+        if not bool_field:
+            self.skipTest("No suitable owned boolean field on res.company")
+
+        original_c1 = self.company_1[bool_field]
+        original_c2 = self.company_2[bool_field]
+
+        result = self.helper._set_values_orm(
+            "res.company",
+            self.company_1.id,
+            bool_field,
+            {
+                str(self.company_1.id): not original_c1,
+                str(self.company_2.id): not original_c2,
+            },
+        )
+        self.assertEqual(self.company_1[bool_field], not original_c1)
+        self.assertEqual(self.company_2[bool_field], not original_c2)
+        self.assertIn(self.company_1.id, result["saved"])
+        self.assertIn(self.company_2.id, result["saved"])
+
+    def test_check_orm_is_specific_non_cd_returns_false(self):
+        """_check_orm_is_specific returns False for fields whose underlying
+        target is a regular res.company column (not CD) — the dialog still
+        works but doesn't pretend a Specific/Default distinction exists."""
+        pair = self._find_settings_related_field()
+        if not pair:
+            self.skipTest("No suitable related field on res.config.settings")
+        settings_field, _company_field = pair
+        settings = self.env["res.config.settings"].create({})
+        Settings = self.env["res.config.settings"]
+        field = Settings._fields[settings_field]
+        # The current company should report False (not "specific" in the
+        # JSONB sense — there's no JSONB for related fields).
+        result = self.helper._check_orm_is_specific(settings, field, self.env.company)
+        self.assertFalse(result)
+
+    # ------------------------------------------------------------------
+    # Public RPC path: set_company_dependent_values(..., mode="orm")
+    # Covers access control and accessible-companies filtering, since the
+    # RPC entrypoint is the one a malicious client would invoke directly.
+    # ------------------------------------------------------------------
+
+    def test_public_orm_filters_inaccessible_companies(self):
+        """A company_id outside env.companies must be skipped (not written)
+        even if it appears in the values_dict — protects against crafted
+        RPC payloads listing arbitrary company IDs."""
+        forbidden = self.env["res.company"].create({"name": "CD Test Forbidden"})
+        Company = self.env["res.company"]
+        bool_field = next(
+            (
+                fname
+                for fname, f in Company._fields.items()
+                if f.type == "boolean" and f.store and not f.related and not f.compute and fname not in ("active",)
+            ),
+            None,
+        )
+        if not bool_field:
+            self.skipTest("No suitable owned boolean field on res.company")
+        original_forbidden = forbidden[bool_field]
+
+        # Force the env to expose only company_1 and company_2 (the ones the
+        # user is allowed into in setUpClass). `forbidden` is not in this set.
+        helper = self.helper.with_context(
+            allowed_company_ids=[self.company_1.id, self.company_2.id],
+        )
+        result = helper.set_company_dependent_values(
+            "res.company",
+            self.company_1.id,
+            bool_field,
+            {
+                str(self.company_1.id): not self.company_1[bool_field],
+                str(forbidden.id): not original_forbidden,
+            },
+            mode="orm",
+        )
+        # The accessible company was written; the forbidden one was skipped.
+        self.assertIn(self.company_1.id, result["saved"])
+        self.assertNotIn(forbidden.id, result["saved"])
+        skipped_ids = [s["id"] for s in result["skipped"]]
+        self.assertIn(forbidden.id, skipped_ids)
+        # The forbidden company's value is untouched.
+        self.assertEqual(forbidden[bool_field], original_forbidden)
+
+    def test_public_orm_enforces_write_access(self):
+        """The public RPC entrypoint must enforce write access on res_model
+        before reaching the ORM branch — same guarantee as the JSON path."""
+        from odoo.exceptions import AccessError
+
+        # Use the demo `portal` user (Joel Willis): in stock Odoo it has no
+        # write access on res.config.settings, so the ir.model.access.check
+        # must raise before any field is touched.
+        portal_user = self.env.ref("base.demo_user0", raise_if_not_found=False) or self.env["res.users"].search(
+            [("login", "=", "portal")], limit=1
+        )
+        if not portal_user:
+            self.skipTest("No portal demo user available")
+        settings = self.env["res.config.settings"].create({})
+        with self.assertRaises(AccessError):
+            self.helper.with_user(portal_user).set_company_dependent_values(
+                "res.config.settings",
+                settings.id,
+                "company_id",
+                {str(self.company_1.id): self.company_1.id},
+                mode="orm",
+            )

--- a/base_company_dependent/views/product_template_views.xml
+++ b/base_company_dependent/views/product_template_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_template_form_view_cd" model="ir.ui.view">
+        <field name="name">product.template.form.company.dependent</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <field name="standard_price" position="attributes">
+                <attribute name="options">
+                    {'currency_field': 'cost_currency_id', 'field_digits': True, 'company_dependent_mode': 'orm'}
+                </attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Summary

Closes the multicompany-UX widget work for v19 (task #62336). On top of the Many2One-only MVP that landed earlier in 19.0:

**Backend (`models/base_company_dependent.py`)**
- ORM-mode strategy (companion to JSONB-native) for fields whose values do not live in a JSONB column: computed fields with `depends_context('company')` and related fields. Auto-detected by `_detect_field_strategy`; can be forced from views via `options=\"{'company_dependent_mode': 'orm'}\"`.
- `_resolve_orm_target` maps `res.config.settings` related to `company_id.*` to `res.company` directly, and `product.template.standard_price` to `product.product` when there is a single variant (fallback for multi-variant keeps the existing inverse-on-template behaviour).
- Company hierarchy up to 3 levels exposed to the dialog for the copy-to-children action.

**Frontend**
- `fields_patch.js` extends the building-icon button to `CharField`, `IntegerField`, `FloatField`, `MonetaryField`, `BooleanField`, `SelectionField` and `DateTimeField` (was Many2One only). `templates.xml` provides the extended OWL templates with matching field shapes and the `o_cd_fallback` muted-display class.
- `settings_patch.js` / `settings_patch.xml` patch `Setting` / `SearchableSetting` so the static `fa-building-o` on `<setting company_dependent=\"1\">` is replaced by the interactive `CompanyDependentButton`. When upstream's compiler does not pass `fieldName` (settings whose first child is a wrapper `<div>`, e.g. `default_taxes`, `default_stock_valuation_accounts`, `main_currency`), the patch discovers the first visible `.o_field_widget[name]` from the rendered DOM and falls back to that field's `string` as label. Strict-equality check on the `companyDependent` prop avoids running the lookup on every setting (upstream passes the literal string `\"false\"` for non-CD settings, which is truthy in JS).

**CSS (`company_dependent.css`)**
- Replace hardcoded light backgrounds (`var(--bs-white)`, `var(--bs-light)`, `var(--bs-gray-100/200)`, `rgba(0, 0, 0, *)`) with Bootstrap 5.3 dark-aware variables (`var(--bs-tertiary-bg)`, `rgba(var(--bs-emphasis-color-rgb), *)`) so the modal hierarchy tinting and hover render correctly in dark mode too.

**Views**
- `product_template_views.xml` adds the orm-mode opt-in on `product.template.standard_price`.

Bump to `19.0.1.2.0` and sync `README.rst`.

## Test plan

- [ ] `odoo-bin -d <db> -u base_company_dependent --test-enable --stop-after-init` — 37 tests green (new ones cover ORM set on `res.company`, target resolution for `res.config.settings` related fields, and the non-CD `is_specific` fallback).
- [ ] Open the Income Account modal on a product, set/copy/reset values across companies — JSONB path unchanged.
- [ ] In Sales / Accounting Settings, click the building icon on a `<setting company_dependent=\"1\">` whose first child is a `<div>` (e.g. `default_taxes`, `main_currency`, `default_stock_valuation_accounts`) — the modal opens for the first visible field and persists changes per company.
- [ ] Toggle dark mode and re-open the modal — hierarchy tinting, hover, header and badges remain legible.
- [ ] `product.template.standard_price` (single-variant) — open the modal, edit per company, the value is delegated to `product.product` JSONB.