### PR TITLE
[IMP] portal_backend: create Portal / Portal Backend users from the Users form

### DIFF
--- a/portal_backend/README.rst
+++ b/portal_backend/README.rst
@@ -46,6 +46,21 @@ You can also create a set of groups that inherit (or not) from each other, but t
         <field name="implied_ids" eval="[Command.link(ref('group_portal_backend_app'))]"/>
     </record>
 
+Creating Portal / Portal Backend users
+======================================
+
+Portal and Portal Backend users can be created directly from *Settings → Users → New*
+(and via import), without having to grant portal access from a contact first. Enable
+developer mode to show the **User Type** selector (Internal / Portal / Portal Backend):
+choosing a type sets the proper groups and the ``share`` flag automatically, so the
+*"exclusive groups"* error never appears. The same result is obtained on import, either
+through the ``Access Type`` column or the ``Role / Portal Backend`` group.
+
+For Portal Backend users, the backend accesses defined under the *Advanced Portal*
+category (e.g. timesheets, holidays) can be granted from a dedicated section in the same
+form. If a contact with the same email already exists, it is reused instead of creating a
+duplicate.
+
 
 Installation
 ============

--- a/portal_backend/__manifest__.py
+++ b/portal_backend/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Portal Backend",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.2.0",
     "category": "Base",
     "sequence": 14,
     "summary": "",
@@ -33,10 +33,16 @@
         "security/res_groups.xml",
         "security/ir.model.access.csv",
         "views/portal_templates.xml",
+        "views/res_users_views.xml",
     ],
     "demo": [
         "demo/res_users_demo.xml",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "portal_backend/static/src/portal_advanced_group_ids/portal_advanced_group_ids_field.js",
+        ],
+    },
     "installable": True,
     "auto_install": False,
     "application": False,

--- a/portal_backend/models/res_users.py
+++ b/portal_backend/models/res_users.py
@@ -2,14 +2,237 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models
+import copy
+
+from odoo import Command, api, fields, models
 
 
 class ResUsers(models.Model):
     _inherit = "res.users"
+
+    access_type = fields.Selection(
+        [
+            ("internal", "Internal User"),
+            ("portal", "Portal"),
+            ("portal_backend", "Portal Backend"),
+        ],
+        compute="_compute_access_type",
+        inverse="_inverse_access_type",
+        store=True,
+        readonly=False,
+        help="Single decision point for the user access type. Internal users get backend access "
+        "(Role / User or Administrator); Portal and Portal Backend are external users (share=True). "
+        "Portal Backend users can additionally be granted Advanced Portal accesses.",
+    )
+    # Dedicated handle for the Advanced Portal accesses, edited through its own widget; the inverse
+    # merges the selection back into group_ids without touching the user-type groups.
+    portal_advanced_group_ids = fields.Many2many(
+        "res.groups",
+        string="Advanced Portal Access",
+        compute="_compute_portal_advanced_group_ids",
+        inverse="_inverse_portal_advanced_group_ids",
+        domain=lambda self: [("privilege_id.category_id", "=", self._portal_advanced_category().id)]
+        if self._portal_advanced_category()
+        else [("id", "=", False)],
+        help="Backend features a Portal Backend user can access (timesheets, holidays, ...). "
+        "Provided by the portal_* modules under the Advanced Portal category.",
+    )
+    # The native groups widget (shown for internal users) lists every category. The Advanced Portal
+    # accesses don't belong there (they imply group_portal, incompatible with an internal user), so
+    # we drop that category from its hierarchy and expose it separately for our dedicated widget.
+    view_group_hierarchy = fields.Json(
+        store=False, copy=False, default=lambda self: self._view_group_hierarchy_without_advanced()
+    )
+    portal_advanced_view_group_hierarchy = fields.Json(
+        store=False, copy=False, default=lambda self: self._portal_advanced_view_group_hierarchy()
+    )
 
     def _is_internal(self):
         self.ensure_one()
         if self.sudo().has_group("portal_backend.group_portal_backend") and self.env.context.get("portal_bypass"):
             return True
         return super()._is_internal()
+
+    # -------------------------------------------------------------------------
+    # access_type <-> groups
+    # -------------------------------------------------------------------------
+    @api.depends("group_ids")
+    def _compute_access_type(self):
+        """Derive the access type from the user groups (source of truth = groups).
+
+        Order matters: an internal user always wins; portal_backend is more specific than
+        plain portal (it implies group_portal), so it must be checked first.
+        """
+        for user in self:
+            if user.has_group("base.group_user"):
+                user.access_type = "internal"
+            elif user.has_group("portal_backend.group_portal_backend"):
+                user.access_type = "portal_backend"
+            elif user.has_group("base.group_portal"):
+                user.access_type = "portal"
+            else:
+                user.access_type = False
+
+    def _inverse_access_type(self):
+        """Translate a manual access_type change into the right groups.
+
+        This is the write/edit path (manual form save). The create path is handled in
+        create() so the disjoint constraint never sees two user-type groups together.
+        share follows automatically from the groups (it has no inverse of its own).
+        """
+        for user in self:
+            if user.access_type:
+                user.group_ids = self._groups_for_access_type(user.group_ids, user.access_type)
+
+    def _view_group_hierarchy_without_advanced(self):
+        """Full group hierarchy minus the Advanced Portal category (for the native widget)."""
+        hierarchy = copy.deepcopy(self.env["res.groups"]._get_view_group_hierarchy())
+        category = self._portal_advanced_category()
+        if category:
+            hierarchy["categories"] = [c for c in hierarchy["categories"] if c["id"] != category.id]
+        return hierarchy
+
+    def _portal_advanced_view_group_hierarchy(self):
+        """Only the Advanced Portal category (for the portal_advanced_group_ids widget)."""
+        empty = {"groups": {}, "privileges": {}, "categories": []}
+        category = self._portal_advanced_category()
+        if not category:
+            return empty
+        full = copy.deepcopy(self.env["res.groups"]._get_view_group_hierarchy())
+        categories = [c for c in full["categories"] if c["id"] == category.id]
+        if not categories:
+            return empty
+        privilege_ids = {pid for c in categories for pid in c["privilege_ids"]}
+        privileges = {k: v for k, v in full["privileges"].items() if v["id"] in privilege_ids}
+        group_ids = {gid for p in privileges.values() for gid in p["group_ids"]}
+        groups = {k: v for k, v in full["groups"].items() if v["id"] in group_ids}
+        return {"groups": groups, "privileges": privileges, "categories": categories}
+
+    @api.depends("group_ids")
+    def _compute_portal_advanced_group_ids(self):
+        advanced = self._portal_advanced_groups()
+        for user in self:
+            user.portal_advanced_group_ids = user.group_ids & advanced
+
+    def _inverse_portal_advanced_group_ids(self):
+        advanced = self._portal_advanced_groups()
+        for user in self:
+            user.group_ids = (user.group_ids - advanced) | user.portal_advanced_group_ids
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        group_user_id = self.env["ir.model.data"]._xmlid_to_res_id("base.group_user")
+        group_portal_id = self.env["ir.model.data"]._xmlid_to_res_id("base.group_portal")
+        group_pb_id = self.env["ir.model.data"]._xmlid_to_res_id("portal_backend.group_portal_backend")
+        for vals in vals_list:
+            access_type = vals.get("access_type")
+            # Path B (import via "Groups / Group Name = Role / Portal Backend"): no access_type column,
+            # but the backend/portal group arrives through group_ids. Derive the type so the same
+            # normalization runs and the stored field/display agree.
+            if not access_type and "group_ids" in vals:
+                ids = self._resolve_group_ids(vals["group_ids"])
+                # Only reclassify when no internal group is imported alongside (group_user wins).
+                if group_user_id not in ids and group_pb_id in ids:
+                    access_type = vals["access_type"] = "portal_backend"
+                elif group_user_id not in ids and group_portal_id in ids:
+                    access_type = vals["access_type"] = "portal"
+            if access_type in ("portal", "portal_backend"):
+                # "Type wins over default": rebuild group_ids without group_user (nor any group that
+                # implies it) so the disjoint constraint never trips. We must also inject group_ids
+                # when absent, otherwise _default_groups() would add group_user during super().create.
+                groups = self.env["res.groups"].browse(self._resolve_group_ids(vals.get("group_ids")))
+                target = self._groups_for_access_type(groups, access_type)
+                vals["group_ids"] = [Command.set(target.ids)]
+                # Reuse an existing contact instead of duplicating it (e.g. importing a portal user
+                # whose email already exists as a contact). Without this, _inherits always creates a
+                # brand new partner. Mirrors the native "Grant portal access" flow for the import case.
+                if not vals.get("partner_id"):
+                    partner = self._portal_partner_to_reuse(vals)
+                    if partner:
+                        vals["partner_id"] = partner.id
+        return super().create(vals_list)
+
+    # -------------------------------------------------------------------------
+    # helpers
+    # -------------------------------------------------------------------------
+    def _groups_for_access_type(self, groups, access_type):
+        """Return the target ``res.groups`` recordset for ``access_type``, from ``groups``.
+
+        Strips every group that implies a *different* user type (the disjoint groups
+        group_user / group_portal / group_public). This is the key fix: internal application
+        groups (e.g. Sales / Purchase added by the *_ux modules) imply group_user, so leaving
+        them behind both tripped the disjoint constraint and made the form revert to Internal.
+        """
+        groups_model = self.env["res.groups"]
+        group_user = self.env.ref("base.group_user")
+        group_portal = self.env.ref("base.group_portal")
+        group_pb = self.env.ref("portal_backend.group_portal_backend")
+        user_type_groups = groups_model._get_user_type_groups()
+        if access_type == "internal":
+            target = group_user
+        elif access_type in ("portal", "portal_backend"):
+            target = group_portal
+        else:
+            return groups
+        other_types = user_type_groups - target
+        # Drop groups implying another user type, plus the user-type groups themselves (re-added below).
+        kept = groups.filtered(lambda g: not (g.all_implied_ids & other_types)) - user_type_groups
+        if access_type == "internal":
+            return kept + group_user
+        if access_type == "portal":
+            # Plain portal: also drop the backend marker and its Advanced Portal accesses.
+            return (kept - group_pb - self._portal_advanced_groups()) + group_portal
+        # portal_backend: Advanced Portal accesses (imply group_pb -> group_portal) survive the filter.
+        return kept + group_pb
+
+    @api.model
+    def _resolve_group_ids(self, group_ids_commands):
+        """Resolve a group_ids x2many command list to a concrete set of group ids.
+
+        Tolerant of the forms the web client / importer / ORM may produce:
+        ``[(6, 0, [ids])]``, ``[(4, id)]``, ``[(3, id)]``, ``Command.*`` aliases, a bare list of
+        ids, or a recordset. For ``create`` there is no pre-existing value, so this is sufficient.
+        """
+        result = set()
+        if not group_ids_commands:
+            return result
+        if isinstance(group_ids_commands, models.BaseModel):
+            return set(group_ids_commands.ids)
+        for command in group_ids_commands:
+            if isinstance(command, int):
+                result.add(command)
+            elif isinstance(command, (list, tuple)):
+                code = command[0]
+                if code in (Command.SET, 6):
+                    result = set(command[2])
+                elif code in (Command.LINK, 4):
+                    result.add(command[1])
+                elif code in (Command.UNLINK, Command.DELETE, 3, 2):
+                    result.discard(command[1])
+                elif code in (Command.CLEAR, 5):
+                    result = set()
+        return result
+
+    @api.model
+    def _portal_partner_to_reuse(self, vals):
+        """Existing contact to link instead of creating a new partner, matched by email.
+
+        Only reuses when the match is unambiguous (exactly one contact) and that contact has no
+        user yet — the typical "grant portal access to an existing contact" case.
+        """
+        email = (vals.get("email") or vals.get("login") or "").strip()
+        if not email:
+            return self.env["res.partner"]
+        partners = self.env["res.partner"].search([("email", "=ilike", email), ("user_ids", "=", False)])
+        return partners if len(partners) == 1 else self.env["res.partner"]
+
+    @api.model
+    def _portal_advanced_category(self):
+        return self.env.ref("portal_backend.category_portal_advanced", raise_if_not_found=False)
+
+    def _portal_advanced_groups(self):
+        """Groups belonging to the Advanced Portal category (timesheets, holidays, etc.)."""
+        category = self._portal_advanced_category()
+        if not category:
+            return self.env["res.groups"]
+        return self.env["res.groups"].sudo().search([("privilege_id.category_id", "=", category.id)])

--- a/portal_backend/static/src/portal_advanced_group_ids/portal_advanced_group_ids_field.js
+++ b/portal_backend/static/src/portal_advanced_group_ids/portal_advanced_group_ids_field.js
@@ -1,0 +1,46 @@
+import { registry } from "@web/core/registry";
+
+/**
+ * Same widget as the native `res_user_group_ids` (privilege-based selection dropdowns), but
+ * restricted to the "Advanced Portal" category, so a Portal Backend user can be granted those
+ * backend accesses with the standard look & feel.
+ *
+ * Implementation: reuse the native component verbatim and only redirect where it reads the group
+ * hierarchy to our pre-filtered `portal_advanced_view_group_hierarchy` field (built server-side,
+ * containing only the Advanced Portal category). The widget is bound to `portal_advanced_group_ids`,
+ * whose inverse merges the selection back into `group_ids` without touching the user-type groups.
+ */
+const fieldsRegistry = registry.category("fields");
+const nativeDef = fieldsRegistry.get("res_user_group_ids");
+
+class PortalAdvancedGroupIdsField extends nativeDef.component {
+    setup() {
+        const record = this.props.record;
+        const dataProxy = new Proxy(record.data, {
+            get: (data, key) =>
+                key === "view_group_hierarchy"
+                    ? data.portal_advanced_view_group_hierarchy
+                    : data[key],
+        });
+        const recordProxy = new Proxy(record, {
+            get: (target, key) => {
+                if (key === "data") {
+                    return dataProxy;
+                }
+                const value = target[key];
+                return typeof value === "function" ? value.bind(target) : value;
+            },
+        });
+        this.props = { ...this.props, record: recordProxy };
+        super.setup();
+    }
+}
+
+fieldsRegistry.add("portal_advanced_group_ids", {
+    ...nativeDef,
+    component: PortalAdvancedGroupIdsField,
+    fieldDependencies: [
+        ...(nativeDef.fieldDependencies || []),
+        { name: "portal_advanced_view_group_hierarchy", type: "json", readonly: true },
+    ],
+});

--- a/portal_backend/tests/__init__.py
+++ b/portal_backend/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_access_type

--- a/portal_backend/tests/test_access_type.py
+++ b/portal_backend/tests/test_access_type.py
@@ -1,0 +1,158 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestAccessType(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Users = cls.env["res.users"].with_context(no_reset_password=True)
+        cls.group_user = cls.env.ref("base.group_user")
+        cls.group_portal = cls.env.ref("base.group_portal")
+        cls.group_pb = cls.env.ref("portal_backend.group_portal_backend")
+
+    def _create(self, login, **vals):
+        return self.Users.create({"name": login, "login": login, **vals})
+
+    # -- manual create -------------------------------------------------------
+    def test_create_internal(self):
+        user = self._create("at_internal", access_type="internal")
+        self.assertEqual(user.access_type, "internal")
+        self.assertFalse(user.share)
+        self.assertIn(self.group_user, user.all_group_ids)
+        self.assertNotIn(self.group_portal, user.all_group_ids)
+
+    def test_create_portal(self):
+        user = self._create("at_portal", access_type="portal")
+        self.assertEqual(user.access_type, "portal")
+        self.assertTrue(user.share)
+        self.assertIn(self.group_portal, user.all_group_ids)
+        self.assertNotIn(self.group_user, user.all_group_ids)
+        self.assertNotIn(self.group_pb, user.all_group_ids)
+
+    def test_create_portal_backend(self):
+        user = self._create("at_pb", access_type="portal_backend")
+        self.assertEqual(user.access_type, "portal_backend")
+        self.assertTrue(user.share)
+        self.assertIn(self.group_pb, user.all_group_ids)
+        # group_pb implies group_portal
+        self.assertIn(self.group_portal, user.all_group_ids)
+        self.assertNotIn(self.group_user, user.all_group_ids)
+
+    # -- the disjoint error must never fire ----------------------------------
+    def test_type_wins_over_internal_role(self):
+        """access_type portal must strip an explicitly requested internal group, no error."""
+        user = self._create(
+            "at_conflict",
+            access_type="portal",
+            group_ids=[Command.link(self.group_user.id)],
+        )
+        self.assertEqual(user.access_type, "portal")
+        self.assertTrue(user.share)
+        self.assertNotIn(self.group_user, user.all_group_ids)
+
+    def test_switch_to_portal_strips_internal_app_groups(self):
+        """Groups implying group_user (e.g. Sales/Purchase from *_ux) must be dropped on switch.
+
+        Reproduces the reported bug: such groups re-imply group_user, so the type reverted to
+        Internal (and would trip the disjoint constraint on save).
+        """
+        app_group = self.env["res.groups"].create(
+            {"name": "Test Internal App", "implied_ids": [Command.link(self.group_user.id)]}
+        )
+        user = self._create("at_appgrp", access_type="internal", group_ids=[Command.link(app_group.id)])
+        self.assertEqual(user.access_type, "internal")
+        user.access_type = "portal"
+        self.assertEqual(user.access_type, "portal")  # must NOT revert to internal
+        self.assertTrue(user.share)
+        self.assertNotIn(app_group, user.all_group_ids)
+        self.assertNotIn(self.group_user, user.all_group_ids)
+
+    def test_portal_advanced_group_ids_inverse(self):
+        """Writing the dedicated field (what the widget does) must add the group to group_ids
+        and keep the user as portal_backend."""
+        advanced = self.env["res.users"]._portal_advanced_groups()
+        if not advanced:
+            self.skipTest("No Advanced Portal groups installed (portal_holidays/timesheet absent)")
+        user = self._create("at_adv", access_type="portal_backend")
+        user.portal_advanced_group_ids = [Command.set(advanced[0].ids)]
+        self.assertIn(advanced[0], user.group_ids)
+        self.assertEqual(user.access_type, "portal_backend")
+        self.assertTrue(user.share)
+        # and removing it again
+        user.portal_advanced_group_ids = [Command.clear()]
+        self.assertNotIn(advanced[0], user.group_ids)
+        self.assertEqual(user.access_type, "portal_backend")
+
+    # -- import parity (Path A: access_type vs Path B: groups) ---------------
+    def test_import_parity_portal_backend(self):
+        path_a = self._create("at_imp_a", access_type="portal_backend")
+        path_b = self._create("at_imp_b", group_ids=[Command.set([self.group_pb.id])])
+        self.assertEqual(path_b.access_type, "portal_backend")
+        self.assertEqual(path_a.share, path_b.share)
+        self.assertEqual(set(path_a.all_group_ids.ids), set(path_b.all_group_ids.ids))
+
+    def test_create_multi_mixed_batch(self):
+        users = self.Users.create(
+            [
+                {"name": "b_int", "login": "b_int", "access_type": "internal"},
+                {"name": "b_por", "login": "b_por", "access_type": "portal"},
+                {"name": "b_pb", "login": "b_pb", "access_type": "portal_backend"},
+            ]
+        )
+        by_login = {u.login: u for u in users}
+        self.assertFalse(by_login["b_int"].share)
+        self.assertTrue(by_login["b_por"].share)
+        self.assertTrue(by_login["b_pb"].share)
+        self.assertIn(self.group_pb, by_login["b_pb"].all_group_ids)
+
+    # -- partner handling ----------------------------------------------------
+    def test_partner_autocreated(self):
+        user = self._create("at_partner", access_type="portal_backend")
+        self.assertTrue(user.partner_id)
+        self.assertEqual(user.partner_id.name, "at_partner")
+
+    def test_partner_reused_when_provided(self):
+        partner = self.env["res.partner"].create({"name": "Existing Contact"})
+        user = self.Users.create({"login": "at_existing", "partner_id": partner.id, "access_type": "portal_backend"})
+        self.assertEqual(user.partner_id, partner)
+
+    def test_partner_reused_by_email_on_import(self):
+        """Importing a portal user whose email matches an existing contact reuses it (no duplicate)."""
+        contact = self.env["res.partner"].create({"name": "Imp Contact", "email": "imp@example.com"})
+        before = self.env["res.partner"].search_count([("email", "=ilike", "imp@example.com")])
+        user = self.Users.create(
+            {
+                "login": "imp@example.com",
+                "name": "Imp Contact",
+                "email": "imp@example.com",
+                "access_type": "portal_backend",
+            }
+        )
+        self.assertEqual(user.partner_id, contact)
+        self.assertEqual(self.env["res.partner"].search_count([("email", "=ilike", "imp@example.com")]), before)
+
+    def test_partner_not_reused_when_ambiguous(self):
+        """Two contacts with the same email -> ambiguous -> create a fresh partner, don't guess."""
+        self.env["res.partner"].create({"name": "Dup A", "email": "dup@example.com"})
+        self.env["res.partner"].create({"name": "Dup B", "email": "dup@example.com"})
+        user = self.Users.create(
+            {"login": "dup@example.com", "name": "Dup", "email": "dup@example.com", "access_type": "portal"}
+        )
+        self.assertNotIn(user.partner_id.name, ("Dup A", "Dup B"))
+
+    # -- write: changing type away from backend cleans advanced accesses -----
+    def test_write_clears_advanced_when_leaving_backend(self):
+        advanced = self.env["res.users"]._portal_advanced_groups()
+        if not advanced:
+            self.skipTest("No Advanced Portal groups installed (portal_holidays/timesheet absent)")
+        user = self._create("at_leave", access_type="portal_backend")
+        user.group_ids = [Command.link(advanced[0].id)]
+        self.assertIn(advanced[0], user.all_group_ids)
+        user.access_type = "internal"
+        self.assertNotIn(advanced[0], user.group_ids)
+        self.assertEqual(user.access_type, "internal")

--- a/portal_backend/views/res_users_views.xml
+++ b/portal_backend/views/res_users_views.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_users_form_portal_backend" model="ir.ui.view">
+        <field name="name">res.users.form.portal_backend</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <!-- access_type is the single decision point for the user access type. It lives in its
+                 own "User Type" section before "Roles" so it stays visible even for external users
+                 (the native "Roles" group hides itself when share=True). -->
+            <!-- The visible "User Type" selector only shows in developer mode, like Odoo 18.
+                 access_type is still loaded everywhere because the modifiers below reference it. -->
+            <xpath expr="//field[@name='role'][@widget='radio']/.." position="before">
+                <group string="User Type" groups="base.group_no_one">
+                    <field name="access_type" widget="radio" options="{'horizontal': true}"
+                           nolabel="1" colspan="2"/>
+                </group>
+            </xpath>
+            <!-- The internal Role radio (User/Administrator) only applies to internal users. -->
+            <xpath expr="//field[@name='role'][@widget='radio']" position="attributes">
+                <attribute name="invisible">access_type != 'internal'</attribute>
+            </xpath>
+            <!-- The native groups widget shows every category (including "Advanced Portal") and is
+                 only meant for internal users. Restrict it to internal so it does not duplicate our
+                 dedicated Advanced Portal section for portal/portal_backend users. -->
+            <xpath expr="//field[@name='group_ids'][@widget='res_user_group_ids'][@groups='!base.group_no_one']" position="attributes">
+                <attribute name="invisible">access_type != 'internal'</attribute>
+            </xpath>
+            <!-- The base form has a SECOND res_user_group_ids node, shown only in developer mode
+                 (groups="base.group_no_one"). Hide it too for non-internal users, otherwise developers
+                 keep seeing the full groups widget (and the duplicate "Advanced Portal" category). -->
+            <xpath expr="//field[@name='group_ids'][@widget='res_user_group_ids'][@groups='base.group_no_one']" position="attributes">
+                <attribute name="invisible">access_type != 'internal'</attribute>
+            </xpath>
+            <!-- Advanced Portal accesses (timesheets, holidays, ...) for Portal Backend users.
+                 The native res_user_group_ids widget is invisible="share", so it never shows for an
+                 external user; this dedicated field (not a third group_ids node, which broke the
+                 widget) is filtered to the Advanced Portal category and gated by access_type. -->
+            <xpath expr="//page[@name='access_rights']" position="inside">
+                <group invisible="access_type != 'portal_backend'">
+                    <field name="portal_advanced_group_ids" widget="portal_advanced_group_ids"
+                           nolabel="1" colspan="2"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Create **Portal** and **Portal Backend** users directly from Settings → Users → New (manual and import), without going through Contacts or hitting the *"exclusive groups"* error.

- **User Type** selector (Internal / Portal / Portal Backend), developer-mode only (v18 parity).
- Sets `share` + groups consistently for manual creation and import, stripping conflicting groups so the exclusive-groups constraint never trips.
- Portal Backend users grant **Advanced Portal** accesses via the native privilege widget (hidden for internal users).
- Reuses an existing contact (matched by email) instead of duplicating it.
