### PR TITLE
[ADD] base_import_ux: First Steps panel for initial imports

### DIFF
--- a/base_import_ux/README.rst
+++ b/base_import_ux/README.rst
@@ -1,0 +1,66 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===========
+First Steps
+===========
+
+ * Adds a "First Steps" section as the first block of General Settings, linking to a single panel that gathers the onboarding initial imports.
+ * Shows each shortcut depending on the installed modules: Import Products (with ``product``), Import Customers / Import Vendors (with ``account_balance_import``, classified through the rank), Import Contacts (otherwise), and the Accounting setup guide (with ``account_balance_import``).
+ * Recommends always using a fresh, clean template downloaded from the system to avoid errors carried by reused spreadsheets.
+
+Installation
+============
+
+Only install the module.
+
+Configuration
+=============
+
+This module does not need any configuration.
+
+Usage
+=====
+
+Go to "Settings > General Settings" and, in the "First Steps" block, click "Open First Steps". The panel shows the available import shortcuts according to the installed modules.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/miscellaneous/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/base_import_ux/__manifest__.py
+++ b/base_import_ux/__manifest__.py
@@ -1,0 +1,48 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "First Steps",
+    "version": "19.0.1.0.0",
+    "category": "Tools",
+    "sequence": 14,
+    "summary": "Centralizes the onboarding initial imports in a single panel "
+    "available from General Settings, showing each shortcut depending on the "
+    "installed modules",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "images": [],
+    "depends": [
+        "base_setup",
+        "base_import",
+    ],
+    "data": [
+        "views/first_steps_actions.xml",
+        "views/res_config_settings_views.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "base_import_ux/static/src/**/*",
+        ],
+    },
+    "installable": True,
+    "auto_install": True,
+    "application": False,
+}

--- a/base_import_ux/static/src/js/first_steps_guide.js
+++ b/base_import_ux/static/src/js/first_steps_guide.js
@@ -1,0 +1,52 @@
+import { _t } from "@web/core/l10n/translation";
+import { ControlPanel } from "@web/search/control_panel/control_panel";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { Component, onWillStart, useState } from "@odoo/owl";
+import { standardActionServiceProps } from "@web/webclient/actions/action_service";
+
+export class FirstStepsGuide extends Component {
+    static template = "base_import_ux.FirstStepsGuide";
+    static components = { ControlPanel };
+    static props = { ...standardActionServiceProps };
+
+    setup() {
+        this.actionService = useService("action");
+        this.orm = useService("orm");
+        this.env.config.setDisplayName(_t("First Steps"));
+
+        // Each card is shown depending on whether the module it needs is
+        // installed. Same pattern as the Enterprise accounting guide (t-if +
+        // searchRead on ir.module.module). Avoids bridge modules: a single
+        // module serves every combination of installed modules.
+        this.state = useState({
+            hasProduct: false,
+            hasStock: false,
+            hasAccountImport: false,
+        });
+
+        onWillStart(async () => {
+            const modules = await this.orm.searchRead(
+                "ir.module.module",
+                [
+                    ["name", "in", ["product", "stock", "account_balance_import"]],
+                    ["state", "=", "installed"],
+                ],
+                ["name"]
+            );
+            const installed = modules.map((m) => m.name);
+            this.state.hasProduct = installed.includes("product");
+            this.state.hasStock = installed.includes("stock");
+            this.state.hasAccountImport = installed.includes("account_balance_import");
+        });
+    }
+
+    // Open an action by XML id. For actions belonging to optional modules (e.g.
+    // accounting) the xmlid is passed as a string: it is resolved only on click,
+    // so it does not create an install dependency.
+    openAction(xmlId) {
+        this.actionService.doAction(xmlId);
+    }
+}
+
+registry.category("actions").add("first_steps_guide", FirstStepsGuide);

--- a/base_import_ux/static/src/xml/first_steps_guide.xml
+++ b/base_import_ux/static/src/xml/first_steps_guide.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="base_import_ux.FirstStepsGuide">
+        <ControlPanel/>
+        <div class="container text-justify overflow-auto h-100">
+            <div class="d-flex flex-column my-5 pt-4">
+                <!-- Data quality recommendation (functional requirement) -->
+                <div class="alert alert-info" role="alert">
+                    <strong>Recommendation:</strong> always use a
+                    <strong>fresh, clean template</strong> downloaded from the
+                    system itself. Reusing old spreadsheets often carries internal
+                    errors that block the import.
+                </div>
+
+                <div class="excel-import pt-4">
+                    <h2 class="text-primary">Initial imports</h2>
+                    <ol class="row list-unstyled" name="first_steps_cards">
+
+                        <!-- Products (requires the product module) -->
+                        <li class="col-lg-6 pt-4" t-if="state.hasProduct">
+                            <div class="row">
+                                <div class="col-lg-10">
+                                    <h3>Import Products</h3>
+                                    <p>
+                                        Import your product catalog.
+                                        <t t-if="state.hasStock">
+                                            The initial physical stock is loaded
+                                            within the same product spreadsheet.
+                                        </t>
+                                    </p>
+                                    <button type="button" class="btn btn-primary"
+                                        t-on-click="() => this.openAction('base_import_ux.action_first_steps_import_product')">
+                                        Import Products
+                                    </button>
+                                </div>
+                                <div class="col-lg-2 border-start"/>
+                            </div>
+                        </li>
+
+                        <!--
+                            With accounting: Customers and Vendors as separate
+                            cards (they get classified). Without accounting: a
+                            single Contacts card. In every case it is res.partner
+                            with the same template.
+                        -->
+                        <t t-if="state.hasAccountImport">
+                            <!-- Customers -->
+                            <li class="col-lg-6 pt-4">
+                                <div class="row">
+                                    <div class="col-lg-10">
+                                        <h3>Import Customers</h3>
+                                        <p>
+                                            Import your customers. They get
+                                            classified and show up in the Customers
+                                            list.
+                                        </p>
+                                        <button type="button" class="btn btn-primary"
+                                            t-on-click="() => this.openAction('base_import_ux.action_first_steps_import_customer')">
+                                            Import Customers
+                                        </button>
+                                    </div>
+                                    <div class="col-lg-2 border-start"/>
+                                </div>
+                            </li>
+
+                            <!-- Vendors -->
+                            <li class="col-lg-6 pt-4">
+                                <div class="row">
+                                    <div class="col-lg-10">
+                                        <h3>Import Vendors</h3>
+                                        <p>
+                                            Import your vendors. They get classified
+                                            and show up in the Vendors list.
+                                        </p>
+                                        <button type="button" class="btn btn-primary"
+                                            t-on-click="() => this.openAction('base_import_ux.action_first_steps_import_supplier')">
+                                            Import Vendors
+                                        </button>
+                                    </div>
+                                    <div class="col-lg-2 border-start"/>
+                                </div>
+                            </li>
+                        </t>
+                        <li class="col-lg-6 pt-4" t-else="">
+                            <div class="row">
+                                <div class="col-lg-10">
+                                    <h3>Import Contacts</h3>
+                                    <p>
+                                        Import customers and vendors along with their
+                                        contacts.
+                                    </p>
+                                    <button type="button" class="btn btn-primary"
+                                        t-on-click="() => this.openAction('base_import_ux.action_first_steps_import_partner')">
+                                        Import Contacts
+                                    </button>
+                                </div>
+                                <div class="col-lg-2 border-start"/>
+                            </div>
+                        </li>
+
+                        <!-- Accounting (requires account_balance_import; xmlid as string) -->
+                        <li class="col-lg-6 pt-4" t-if="state.hasAccountImport">
+                            <div class="row">
+                                <div class="col-lg-10">
+                                    <h3>Accounting setup</h3>
+                                    <p>
+                                        Set up your initial accounting: chart of
+                                        accounts, periods, partner balances and
+                                        document import.
+                                    </p>
+                                    <button type="button" class="btn btn-primary"
+                                        t-on-click="() => this.openAction('account_base_import.action_open_import_guide')">
+                                        Open accounting guide
+                                    </button>
+                                </div>
+                                <div class="col-lg-2 border-start"/>
+                            </div>
+                        </li>
+
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/base_import_ux/views/first_steps_actions.xml
+++ b/base_import_ux/views/first_steps_actions.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Client action: "First Steps" panel (initial imports guide) -->
+    <record id="action_first_steps_guide" model="ir.actions.client">
+        <field name="name">First Steps</field>
+        <field name="tag">first_steps_guide</field>
+        <field name="target">current</field>
+    </record>
+
+    <!--
+        Standard import actions (base_import). The params field is just a dict
+        (no FK to the model), so these records load even when the model's module
+        is not installed; the card is hidden via t-if.
+
+        The product action mirrors the context of the Inventory > Products action
+        (stock_ux' product_template_action_product): default_is_storable plus the
+        stock_product_template flag, which makes get_import_templates serve the
+        improved Adhoc product template (with stock columns) instead of the base
+        one. The flag is just a context key, so it is a no-op when stock_ux is not
+        installed (no dependency added).
+    -->
+    <record id="action_first_steps_import_product" model="ir.actions.client">
+        <field name="name">Import Products</field>
+        <field name="tag">import</field>
+        <field name="target">current</field>
+        <field name="params" eval="{'model': 'product.template', 'context': {'search_default_goods': 1, 'default_is_storable': True, 'stock_product_template': 1}}"/>
+    </record>
+
+    <!--
+        contact_import mirrors base_ux' Contacts action so get_import_templates
+        serves the improved Adhoc contacts template; default_is_company matches
+        the standard Contacts default. Both are plain context keys (no-op when
+        base_ux is absent).
+    -->
+    <record id="action_first_steps_import_partner" model="ir.actions.client">
+        <field name="name">Import Contacts</field>
+        <field name="tag">import</field>
+        <field name="target">current</field>
+        <field name="params" eval="{'model': 'res.partner', 'context': {'default_is_company': True, 'contact_import': 1}}"/>
+    </record>
+
+    <!--
+        Customers and Vendors are the same res.partner model. The
+        res_partner_search_mode flag makes sale_ux / purchase_ux'
+        get_import_templates serve their improved customer / vendor templates
+        (and triggers the right search mode), while default_*_rank classifies the
+        imported record so it shows up in the matching list. This mirrors the
+        native Customers / Vendors actions; all keys are no-ops when the related
+        module is not installed.
+    -->
+    <record id="action_first_steps_import_customer" model="ir.actions.client">
+        <field name="name">Import Customers</field>
+        <field name="tag">import</field>
+        <field name="target">current</field>
+        <field name="params" eval="{'model': 'res.partner', 'context': {'res_partner_search_mode': 'customer', 'default_is_company': True, 'default_customer_rank': 1}}"/>
+    </record>
+
+    <record id="action_first_steps_import_supplier" model="ir.actions.client">
+        <field name="name">Import Vendors</field>
+        <field name="tag">import</field>
+        <field name="target">current</field>
+        <field name="params" eval="{'model': 'res.partner', 'context': {'res_partner_search_mode': 'supplier', 'default_is_company': True, 'default_supplier_rank': 1}}"/>
+    </record>
+
+</odoo>

--- a/base_import_ux/views/res_config_settings_views.xml
+++ b/base_import_ux/views/res_config_settings_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.base.import.ux</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <!-- Insert the section as the first block inside General Settings -->
+            <xpath expr="//block[@name='users_setting_container']" position="before">
+                <block title="First Steps" name="first_steps_setting_container">
+                    <setting
+                        string="Initial imports"
+                        help="Run here the imports you need to get your system up and running.">
+                        <div class="content-group">
+                            <div class="mt8">
+                                <button
+                                    name="%(base_import_ux.action_first_steps_guide)d"
+                                    icon="oi-arrow-right"
+                                    type="action"
+                                    string="Open First Steps"
+                                    class="btn-link"/>
+                            </div>
+                        </div>
+                    </setting>
+                </block>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Qué hace

Agrega el módulo horizontal **base_import_ux**, que expone un panel **First Steps** ("Primeros Pasos") como **primer bloque de Ajustes Generales**, centralizando las importaciones iniciales del onboarding en un solo lugar.

## Detalle

- **Panel** = `ir.actions.client` + componente OWL que renderiza tarjetas de acceso a las importaciones.
- **Tarjetas condicionadas en runtime** según módulos instalados (consulta a `ir.module.module`), sin módulos puente: un único módulo sirve para todas las combinaciones.
  - **Import Products** → si está `product` (menciona stock si está `stock`).
  - **Import Customers / Import Vendors** → si está `account_balance_import`; mismo `res.partner` con `default_customer_rank` / `default_supplier_rank` para que queden clasificados.
  - **Import Contacts** → alternativa cuando no hay contabilidad.
  - **Accounting setup** → si está `account_balance_import`; abre la guía existente `account_base_import.action_open_import_guide` (acceso directo por xmlid string, sin acoplar dependencias).
- Recomienda usar plantillas nuevas y limpias descargadas del sistema.
- Depende solo de `base_setup` + `base_import` (horizontal, instala en cualquier base).

## Patrón

Mismo enfoque que la guía de importación Enterprise (`account_base_import`): gating de tarjetas vía `t-if` + chequeo de módulos instalados.