### PR TITLE
[FIX] portal_backend: avoid registry cache invalidation storm on menu load

### DIFF
--- a/portal_backend/models/ir_ui_menu.py
+++ b/portal_backend/models/ir_ui_menu.py
@@ -11,7 +11,12 @@ class IrUiMenu(models.Model):
         # It is important to do it here to capture the case when portal_backend is already installed and the user
         # installs another module with a parent menu without internal group.
         parent_menus_wo_group = self.sudo().search([("parent_id", "=", False), ("groups_id", "=", False)])
-        parent_menus_wo_group.with_context(from_config=True).write(
-            {"groups_id": [Command.link(self.env.ref("base.group_user").id)]}
-        )
+        # Evitamos el write (y su clear_cache global) cuando no hay nada que corregir.
+        # ir.ui.menu.write invalida el registry de forma incondicional; como load_menus
+        # está cacheado, un write en cada llamada invalida su propio cache y genera una
+        # tormenta de invalidaciones cross-worker en cada carga de menús.
+        if parent_menus_wo_group:
+            parent_menus_wo_group.with_context(from_config=True).write(
+                {"groups_id": [Command.link(self.env.ref("base.group_user").id)]}
+            )
         return super().load_menus(debug=debug)

--- a/portal_backend/tests/__init__.py
+++ b/portal_backend/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_load_menus_cache

--- a/portal_backend/tests/test_load_menus_cache.py
+++ b/portal_backend/tests/test_load_menus_cache.py
@@ -1,0 +1,37 @@
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+from unittest.mock import patch
+
+from odoo import Command
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestLoadMenusCache(TransactionCase):
+    """load_menus is cached by ormcache; it must not invalidate the registry on
+    every call. ir.ui.menu.write clears the whole registry unconditionally, so
+    writing on each load_menus invalidates its own cache and produces an
+    invalidation storm under repeated screen reloads.
+    """
+
+    def _load_menus_clear_cache_calls(self):
+        # force a cache miss so load_menus actually runs
+        self.env.registry.clear_cache()
+        with patch.object(type(self.env.registry), "clear_cache") as mock_clear:
+            self.env["ir.ui.menu"].load_menus(False)
+        return mock_clear.call_count
+
+    def test_no_invalidation_when_no_root_menu_without_group(self):
+        """With every root menu already having a group, load_menus must not write
+        (and therefore must not invalidate the registry cache)."""
+        menus = self.env["ir.ui.menu"].sudo()
+        wo_group = menus.search([("parent_id", "=", False), ("groups_id", "=", False)])
+        wo_group.write({"groups_id": [Command.link(self.env.ref("base.group_user").id)]})
+
+        self.assertEqual(
+            self._load_menus_clear_cache_calls(),
+            0,
+            "load_menus must not invalidate the registry cache when there are no "
+            "root menus without an internal group.",
+        )


### PR DESCRIPTION
Helpdesk ticket 121341.

### Problem
`portal_backend` overrides `ir.ui.menu.load_menus`, which is cached with `@tools.ormcache_context`. The override **unconditionally** writes on the root menus without an internal group:

```python
parent_menus_wo_group = self.sudo().search([("parent_id", "=", False), ("groups_id", "=", False)])
parent_menus_wo_group.with_context(from_config=True).write({...})
```

`ir.ui.menu.write` (base) calls `self.env.registry.clear_cache()` as its first line, **unconditionally** — even when the recordset is empty. So every `load_menus` call invalidates the whole registry cache, which includes the `load_menus` ormcache itself. The next menu load is then a cache miss that writes again and re-invalidates → a self-sustaining **cross-worker cache-invalidation storm**. Under repeated screen reloads (every screen load triggers `load_menus`) this saturates all workers rebuilding the registry and severely slows the instance down.

Confirmed on a real database: every menu load emitted a `Caches invalidated, signaling through the database`, traced back to this exact write.

### Fix
Only write when there actually are root menus without a group. In the common case (none), `load_menus` no longer writes and no longer invalidates the cache, so it stays cached. The group is still assigned the first time a new root menu without a group appears (e.g. after installing a module).

### Test plan
New `portal_backend/tests/test_load_menus_cache.py` (mocks `registry.clear_cache`):
- `test_no_invalidation_when_no_root_menu_without_group` — with all root menus already grouped, `load_menus` triggers 0 cache invalidations.

Green locally on 18.0.