### PR TITLE
[IMP] base_ux: add empty-state placeholder to ModelFieldSelector

### DIFF
--- a/base_ux/__manifest__.py
+++ b/base_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Base UX",
-    "version": "19.0.1.6.0",
+    "version": "19.0.1.7.0",
     "category": "Base",
     "sequence": 14,
     "summary": "",
@@ -40,6 +40,11 @@
         "views/mail_activity_schedule_view.xml",
         "views/res_partner_views.xml",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "base_ux/static/src/model_field_selector/model_field_selector.xml",
+        ],
+    },
     "demo": [],
     "test": [],
     "installable": True,

--- a/base_ux/i18n/base_ux.pot
+++ b/base_ux/i18n/base_ux.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-29 14:04+0000\n"
-"PO-Revision-Date: 2026-06-29 14:04+0000\n"
+"POT-Creation-Date: 2026-06-29 18:29+0000\n"
+"PO-Revision-Date: 2026-06-29 18:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -140,6 +140,12 @@ msgstr ""
 #. module: base_ux
 #: model_terms:ir.ui.view,arch_db:base_ux.view_window_action_form
 msgid "Remove the contextual action related this action"
+msgstr ""
+
+#. module: base_ux
+#. odoo-javascript
+#: code:addons/base_ux/static/src/model_field_selector/model_field_selector.xml:0
+msgid "Select a field..."
 msgstr ""
 
 #. module: base_ux

--- a/base_ux/static/src/model_field_selector/model_field_selector.xml
+++ b/base_ux/static/src/model_field_selector/model_field_selector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-inherit="web._ModelFieldSelector" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o_model_field_selector_value')]" position="inside">
+            <span t-if="!props.readonly and !state.displayNames.length" class="o_model_field_selector_placeholder text-muted px-1">Select a field...</span>
+        </xpath>
+    </t>
+
+</templates>


### PR DESCRIPTION
## What

Extends the core web `ModelFieldSelector` OWL template to show a muted
"Select a field..." placeholder when the field chain is empty and the widget is
in edit mode.

## Why

When the chain is empty, the core component renders the value container as an
invisible ~20x20px box with no border, chip or placeholder. Users do not realize
it is a clickable input until they hover over it (the dotted line only appears on
hover). Reported during a usability session; the most visible case is the
*Update Record* server action in Automation Rules.

## How

New asset `base_ux/static/src/model_field_selector/model_field_selector.xml`: a
`t-inherit="web._ModelFieldSelector" t-inherit-mode="extension"` that appends a
placeholder `<span>` inside `.o_model_field_selector_value`, gated by
`!props.readonly and !state.displayNames.length`. No Python, no JS, no SCSS — the
span uses Bootstrap utility classes. `web` is not added to `depends` (it is
already pulled in transitively via `mail`).

## Test plan

1. Settings → Technical → Automation Rules → create a rule → add an *Update
   Record* action.
2. The field-to-update selector now shows "Select a field..." while empty
   (previously a blank invisible box).
3. Pick a field → the placeholder disappears and the chain renders as before.
4. Readonly contexts are unaffected (placeholder only shows in edit mode).

## Notes

- Assets-only change. Suggested merge policy: `nobump` (manifest minor already
  set to 19.0.1.6.0). Note: the new `ir.asset` requires the module to be updated
  on deploy for the override to take effect.
- Companion PR for the same usability report (project stage Selection field):
  ingadhoc/project#144.

Internal task: 69981
