### PR TITLE
[FIX] base_bg: retry job acquisition on serialization failure

### DIFF
--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -13,6 +13,12 @@ from odoo.fields import Domain
 
 _logger = logging.getLogger(__name__)
 
+# Number of times a worker retries acquiring the next job when it loses the race
+# against a concurrent worker (SerializationFailure). Retrying in-process absorbs the
+# transient contention instead of surrendering and rescheduling every cron at once
+# (trigger storm). Mirrors saas_provider.saas_database._acquire_next_task.
+MAX_ACQUIRE_RETRIES = 5
+
 
 class BgJob(models.Model):
     _name = "bg.job"
@@ -326,6 +332,14 @@ class BgJob(models.Model):
         Uses SELECT FOR UPDATE SKIP LOCKED to avoid conflicts with other cron jobs.
         Not only grabs the next job, but also marks it as running.
 
+        Under Odoo's default REPEATABLE READ isolation, SKIP LOCKED does not fully
+        prevent conflicts: if a concurrent worker already grabbed and committed the
+        head-of-queue row, this transaction (older snapshot) still selects it, the row
+        is no longer locked so it is not skipped, and the UPDATE raises a
+        SerializationFailure. This is expected under contention and handled by the
+        caller (_cron_run_enqueued_jobs) with a bounded retry, so it must not be logged
+        as a "bad query" ERROR — hence log_exceptions=False.
+
         :return: The next BgJob record to process, or an empty recordset if none available
         """
         self.env.cr.execute(
@@ -344,7 +358,8 @@ class BgJob(models.Model):
             FROM candidate
             WHERE j.id = candidate.id
             RETURNING j.id;
-            """
+            """,
+            log_exceptions=False,
         )
         row = self.env.cr.fetchone()
         return self.browse(row[0]) if row else self.env["bg.job"]
@@ -357,13 +372,32 @@ class BgJob(models.Model):
         Uses SELECT FOR UPDATE SKIP LOCKED to allow multiple crons to safely
         pick up jobs without conflicts. Each cron processes one available job
         that isn't locked by other crons, naturally balancing the load.
+
+        Retry on SerializationFailure (concurrent workers racing on the same row).
+        Since no writes have been done yet at this point, rolling back and retrying
+        in-process is safe and avoids the trigger storm caused by all workers
+        surrendering at once and rescheduling each other.
         """
-        try:
-            job = self._get_next_job()
-        except psycopg2.errors.SerializationFailure:
-            self.env.cr.rollback()
-            self.env["base.bg"].sudo()._trigger_crons()
-            return
+        job = None
+        for attempt in range(MAX_ACQUIRE_RETRIES):
+            try:
+                job = self._get_next_job()
+                break
+            except psycopg2.errors.SerializationFailure:
+                self.env.cr.rollback()
+                if attempt == MAX_ACQUIRE_RETRIES - 1:
+                    _logger.warning(
+                        "Failed to acquire next background job after %d attempts due to "
+                        "concurrent workers; rescheduling.",
+                        MAX_ACQUIRE_RETRIES,
+                    )
+                    self.env["base.bg"].sudo()._trigger_crons()
+                    return
+            except Exception:
+                # Any other (unexpected) error leaves the transaction aborted; roll it
+                # back so the cursor is clean before propagating, and do not retry.
+                self.env.cr.rollback()
+                raise
 
         if not job:
             return

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -6,8 +6,10 @@ from datetime import timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
+import psycopg2
 from odoo import fields, tools
 from odoo.addons.base_bg.models.base_bg import BaseBg
+from odoo.addons.base_bg.models.bg_job import MAX_ACQUIRE_RETRIES
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
@@ -498,3 +500,71 @@ class TestBgJob(TransactionCase):
         with patch.object(type(job1), "run"), patch.object(type(self.env["base.bg"]), "_trigger_crons") as mock_trigger:
             self.BgJob._cron_run_enqueued_jobs()
             mock_trigger.assert_called_once()
+
+    def test_cron_run_retries_on_serialization_failure(self):
+        """A SerializationFailure while acquiring a job must be retried in-process,
+        not surrendered on the first conflict (which caused the trigger storm)."""
+        partner = self.env["res.partner"].create({"name": "Retry Partner"})
+        job = self._create_job(
+            name="Retry Race Job",
+            model="res.partner",
+            method="exists",
+            kwargs_json={"_record_ids": [partner.id]},
+            state="enqueued",
+        )
+        # First acquire loses the race; the retry succeeds and returns the job.
+        outcomes = [psycopg2.errors.SerializationFailure(), job]
+
+        def fake_get_next_job():
+            outcome = outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        with (
+            patch.object(type(self.BgJob), "_get_next_job", side_effect=fake_get_next_job) as mock_get,
+            patch.object(self.env.cr, "rollback"),
+            patch.object(type(job), "run") as mock_run,
+        ):
+            self.BgJob._cron_run_enqueued_jobs()
+
+        self.assertEqual(mock_get.call_count, 2, "must retry once after the SerializationFailure")
+        mock_run.assert_called_once()
+
+    def test_cron_run_surrenders_after_max_retries(self):
+        """After MAX_ACQUIRE_RETRIES consecutive SerializationFailures, the cron
+        reschedules and returns without running a job."""
+        with (
+            patch.object(
+                type(self.BgJob),
+                "_get_next_job",
+                side_effect=psycopg2.errors.SerializationFailure(),
+            ) as mock_get,
+            patch.object(self.env.cr, "rollback"),
+            patch.object(type(self.env["base.bg"]), "_trigger_crons") as mock_trigger,
+            patch("odoo.addons.base_bg.models.bg_job._logger.warning") as mock_warning,
+        ):
+            result = self.BgJob._cron_run_enqueued_jobs()
+
+        self.assertIsNone(result)
+        self.assertEqual(mock_get.call_count, MAX_ACQUIRE_RETRIES)
+        mock_trigger.assert_called_once()
+        mock_warning.assert_called_once()
+
+    def test_cron_run_reraises_unexpected_error(self):
+        """An error other than SerializationFailure must not be retried: the cron
+        rolls back the aborted transaction and propagates it (no silent swallow)."""
+        with (
+            patch.object(
+                type(self.BgJob),
+                "_get_next_job",
+                side_effect=ValueError("boom"),
+            ) as mock_get,
+            patch.object(self.env.cr, "rollback") as mock_rollback,
+        ):
+            with self.assertRaises(ValueError):
+                self.BgJob._cron_run_enqueued_jobs()
+
+        # Not retried, and the transaction is rolled back before propagating.
+        self.assertEqual(mock_get.call_count, 1)
+        mock_rollback.assert_called_once()


### PR DESCRIPTION
## Qué

`bg.job._get_next_job` compite contra otros cron-workers concurrentes bajo el isolation REPEATABLE READ por defecto de Odoo, donde `FOR UPDATE SKIP LOCKED` no evita un `SerializationFailure` cuando otro worker ya agarró y commiteó el job del tope de la cola. El error se ve seguido en logs de producción como `odoo.sql_db: bad query ... could not serialize access due to concurrent update`.

Aunque la excepción ya estaba capturada y manejada (rollback + re-trigger), aparece como ERROR porque `odoo.sql_db` loguea toda query que falla antes de que la excepción llegue al `except`. Además, rendirse al primer conflicto y re-disparar todos los crons genera un "trigger storm".

## Cambios

- `log_exceptions=False` en la query de `_get_next_job`: la falla es esperada y manejada, no debe loguearse como `bad query` ERROR.
- Retry loop acotado (`MAX_ACQUIRE_RETRIES = 5`) en `_cron_run_enqueued_jobs` en vez de rendirse al primer conflicto.

Espeja el patrón ya usado en `saas_provider.saas_database._acquire_next_task`.

## Test plan

- Tests nuevos: `test_cron_run_retries_on_serialization_failure` (reintenta y recupera) y `test_cron_run_surrenders_after_max_retries` (tras N fallas: warn + reschedule + return sin correr job).
- Suite completa de `base_bg`: 30/30 OK (`--test-tags /base_bg`).

Task: #70485 (I+D Mejoras)