### PR TITLE
[ADD] base_import_ux: show import action on small screens

### DIFF
--- a/base_import_mobile_ux/README.rst
+++ b/base_import_mobile_ux/README.rst
@@ -1,0 +1,54 @@
+==========================
+Base Import Mobile UX
+==========================
+
+Show the Import action in the list view gear menu on small screens
+
+Características
+===============
+
+- Muestra la opción "Importar registros" en el menú de acciones (engranaje)
+  de la vista lista cuando la pantalla es chica (mobile), donde el core de
+  Odoo la oculta por defecto.
+- No cambia ningún otro criterio de visibilidad: sigue respetando el tipo de
+  acción, el tipo de vista, y los atributos ``import``/``create`` del arch,
+  tal como los define el core.
+
+Detalles Técnicos
+=================
+
+- No agrega modelos nuevos ni hereda modelos existentes.
+- ``static/src/import_records.js``: re-registra la entrada ``import-menu``
+  del registry ``cogMenu`` (``registry.category("cogMenu")``), reutilizando
+  ``importRecordsItem`` de ``base_import`` y forzando ``isSmall`` a ``false``
+  al evaluar su condición ``isDisplayed``, sin duplicar el resto de la lógica
+  original.
+
+Uso
+===
+
+Con el módulo instalado, al abrir cualquier vista lista desde una pantalla
+angosta (mobile), el menú de acciones (ícono de engranaje) incluye la opción
+"Importar registros" además de las que ya se mostraban.
+
+Arquitectura
+============
+
+Módulo puramente de frontend: un único asset JS cargado en
+``web.assets_backend`` que sobreescribe una entrada del registry ``cogMenu``
+del core. No tiene lógica Python, vistas ni datos.
+
+Dependencias
+============
+
+- base_import
+
+Autor
+=====
+
+ADHOC SA
+
+Licencia
+========
+
+AGPL-3

--- a/base_import_mobile_ux/__manifest__.py
+++ b/base_import_mobile_ux/__manifest__.py
@@ -1,0 +1,40 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Base Import Mobile UX",
+    "version": "19.0.1.0.0",
+    "category": "Base",
+    "author": "ADHOC SA",
+    "website": "https://www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Show the Import action in the list view gear menu on small screens",
+    "depends": [
+        "base_import",
+    ],
+    "data": [],
+    "assets": {
+        "web.assets_backend": [
+            "base_import_mobile_ux/static/src/import_records.js",
+        ],
+    },
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/base_import_mobile_ux/static/src/import_records.js
+++ b/base_import_mobile_ux/static/src/import_records.js
@@ -1,0 +1,31 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { importRecordsItem } from "@base_import/import_records/import_records";
+
+const cogMenuRegistry = registry.category("cogMenu");
+
+/**
+ * Core hides the "Import records" gear menu item on small screens
+ * (isDisplayed checks `!isSmall`, see base_import/import_records.js).
+ * That's intentional for the default import wizard, but some clients
+ * still want the entry available on mobile. Re-register the same item,
+ * only forcing `isSmall` to false so the rest of the original condition
+ * (view type, `import`/`create` arch attributes, action type) still applies.
+ *
+ * Owl envs are built with `Object.create` (prototypal, frozen) — `config`
+ * lives on a prototype, not as an own property. A plain `{...env}` spread
+ * only copies own properties and drops `config`, so `Object.create` is used
+ * here to shadow `isSmall` while keeping the rest of the chain intact.
+ */
+cogMenuRegistry.add(
+    "import-menu",
+    {
+        ...importRecordsItem,
+        isDisplayed: (env) =>
+            importRecordsItem.isDisplayed(
+                Object.create(env, { isSmall: { value: false, enumerable: true } })
+            ),
+    },
+    { force: true, sequence: 1 }
+);


### PR DESCRIPTION
## Summary

Odoo core hides the "Import records" gear-menu action in list views on small screens (`isDisplayed` in `base_import`'s `import_records.js` short-circuits on `!isSmall`). This adds an opt-in module, `base_import_ux`, that re-registers that `cogMenu` item forcing `isSmall` to `false` when evaluating the original condition, so the rest of the check (action type, view type, `import`/`create` arch attributes) is untouched — only the small-screen gate is removed.

`export-all-menu` (the "Export" gear-menu item) has no `isSmall` check at all, which is why Export already survives on mobile while Import doesn't — this module brings Import to parity for clients that want it.

The module depends only on `base_import` and touches no other behavior. It's kept as a standalone, non-auto-installed module (rather than folded into `base_ux`) since Odoo hides this action on small screens on purpose — the import wizard's column-mapping UI isn't mobile-optimized — so the change should be opt-in per client, not forced everywhere.

## Test plan

- [ ] Install `base_import_ux` on a v19 test database.
- [ ] Open any list view (e.g. Contacts) with the browser viewport narrowed to mobile width.
- [ ] Open the gear menu — "Import records" should now appear (previously absent), "Export" still present.
- [ ] Confirm no console errors from the asset bundle.