### PR TITLE
[FIX] portal_backend: include subcategories in Advanced Portal category filters

### DIFF
--- a/portal_backend/models/res_users.py
+++ b/portal_backend/models/res_users.py
@@ -85,21 +85,27 @@ class ResUsers(models.Model):
                 user.group_ids = self._groups_for_access_type(user.group_ids, user.access_type)
 
     def _view_group_hierarchy_without_advanced(self):
-        """Full group hierarchy minus the Advanced Portal category (for the native widget)."""
+        """Full group hierarchy minus the Advanced Portal category and its subcategories (for the native widget)."""
         hierarchy = copy.deepcopy(self.env["res.groups"]._get_view_group_hierarchy())
         category = self._portal_advanced_category()
         if category:
-            hierarchy["categories"] = [c for c in hierarchy["categories"] if c["id"] != category.id]
+            category_ids = self.env["ir.module.category"].search([("id", "child_of", category.id)]).ids
+            hierarchy["categories"] = [c for c in hierarchy["categories"] if c["id"] not in category_ids]
         return hierarchy
 
     def _portal_advanced_view_group_hierarchy(self):
-        """Only the Advanced Portal category (for the portal_advanced_group_ids widget)."""
+        """The Advanced Portal category and its subcategories (for the portal_advanced_group_ids widget).
+
+        Modules like academic nest their own category under Advanced Portal (parent_id) to keep
+        their subtitle in the widget; child_of pulls those in too, not just the exact category.
+        """
         empty = {"groups": {}, "privileges": {}, "categories": []}
         category = self._portal_advanced_category()
         if not category:
             return empty
+        category_ids = self.env["ir.module.category"].search([("id", "child_of", category.id)]).ids
         full = copy.deepcopy(self.env["res.groups"]._get_view_group_hierarchy())
-        categories = [c for c in full["categories"] if c["id"] == category.id]
+        categories = [c for c in full["categories"] if c["id"] in category_ids]
         if not categories:
             return empty
         privilege_ids = {pid for c in categories for pid in c["privilege_ids"]}
@@ -231,8 +237,8 @@ class ResUsers(models.Model):
         return self.env.ref("portal_backend.category_portal_advanced", raise_if_not_found=False)
 
     def _portal_advanced_groups(self):
-        """Groups belonging to the Advanced Portal category (timesheets, holidays, etc.)."""
+        """Groups belonging to the Advanced Portal category or one of its subcategories (timesheets, holidays, etc.)."""
         category = self._portal_advanced_category()
         if not category:
             return self.env["res.groups"]
-        return self.env["res.groups"].sudo().search([("privilege_id.category_id", "=", category.id)])
+        return self.env["res.groups"].sudo().search([("privilege_id.category_id", "child_of", category.id)])

--- a/portal_backend/static/src/portal_advanced_group_ids/portal_advanced_group_ids_field.js
+++ b/portal_backend/static/src/portal_advanced_group_ids/portal_advanced_group_ids_field.js
@@ -16,16 +16,22 @@ const nativeDef = fieldsRegistry.get("res_user_group_ids");
 class PortalAdvancedGroupIdsField extends nativeDef.component {
     setup() {
         const record = this.props.record;
-        const dataProxy = new Proxy(record.data, {
-            get: (data, key) =>
-                key === "view_group_hierarchy"
-                    ? data.portal_advanced_view_group_hierarchy
-                    : data[key],
-        });
         const recordProxy = new Proxy(record, {
             get: (target, key) => {
                 if (key === "data") {
-                    return dataProxy;
+                    // Wrap `target.data` fresh on every access instead of caching a single Proxy
+                    // bound to the `record.data` reference seen at setup() time: on a cold load,
+                    // the record can still be hydrating when setup() runs, and Odoo later swaps in
+                    // the fully-loaded `data` object rather than mutating the placeholder in place.
+                    // A one-time-captured proxy keeps pointing at that stale placeholder forever,
+                    // so the widget renders the group selected before the real data arrived (fixed
+                    // only by a second reload, once the swap already happened on the previous load).
+                    return new Proxy(target.data, {
+                        get: (data, dataKey) =>
+                            dataKey === "view_group_hierarchy"
+                                ? data.portal_advanced_view_group_hierarchy
+                                : data[dataKey],
+                    });
                 }
                 const value = target[key];
                 return typeof value === "function" ? value.bind(target) : value;


### PR DESCRIPTION
## Summary

Modules that extend Advanced Portal (e.g. academic) nest their own `ir.module.category` under `portal_backend.category_portal_advanced` via `parent_id`, to keep their own subtitle in the widget. The three methods in `res_users.py` that derive the Advanced Portal group hierarchy matched categories by exact id equality instead of the descendant set:

- `_portal_advanced_view_group_hierarchy`: only included the category whose id was exactly `category_portal_advanced`, so any nested category (with its privileges/groups) was silently dropped from the `portal_advanced_group_ids` widget.
- `_portal_advanced_groups`: same issue — `privilege_id.category_id = category.id` missed groups whose privilege lives in a nested category.
- `_view_group_hierarchy_without_advanced`: excluded only the exact category from the native groups widget, so a nested category ended up leaking into the widget it's supposed to be excluded from.

Additionally, the `portal_advanced_group_ids` widget (`portal_advanced_group_ids_field.js`) wrapped `record.data` in a `Proxy` once in `setup()`, caching that reference forever. On a cold reload the record can still be hydrating when `setup()` runs, and the framework later swaps in the fully-loaded `data` object rather than mutating the placeholder in place — so the cached proxy kept reflecting the group selected before the last edit until a second reload.

## Fix

- Switch category matching from `=`/`==` to `child_of` (via `ir.module.category`'s native `parent_id` hierarchy) in all three `res_users.py` methods, so nested categories are included where they should be, and excluded where they shouldn't.
- Rebuild the widget's `data` proxy on every access instead of caching it once, so it always reflects the current `record.data` reference.

## Test plan

- [x] `py_compile` passes.
- [x] `pre-commit` passes (ruff, ruff-format, pylint-odoo).
- [x] Manual (local test DB with `academic` installed, Playwright-driven): opened a Portal Backend user's profile, confirmed the "Portal Academic" section is visible under Advanced Portal accesses with its own subtitle. Changed the selection, saved, and reloaded — the new value now shows correctly on the first reload (previously required a second reload), verified in both directions (Parent↔Teacher).