### PR TITLE
[FIX] base_ux: keep quick activity badges when editing an activity

### DIFF
--- a/base_ux/README.rst
+++ b/base_ux/README.rst
@@ -21,7 +21,7 @@ Several Improvements:
     * Make parent field on res.company invisible as it is useless now
     * Keep the activity's description when changing the activity type, regardless of the activity type's description, and change the activity user only if the activity type has a default user.
     * Make company_registry field on res.company invisible as it is useless now
-    * Show or hide the activity badge widget depending on the number of activity types defined in the system (configurable threshold, default to 5).
+    * On the "Schedule Activity" dialog, show only the first N activity types (ordered by sequence) as quick badges, plus a dropdown to search among all the remaining ones. It applies both when scheduling a new activity and when editing an existing one; on an existing activity its current type is always kept among the badges. N is set through the system parameter base_ux.activity_quick_badges (default to 5).
 
 
 Installation

--- a/base_ux/__manifest__.py
+++ b/base_ux/__manifest__.py
@@ -38,6 +38,7 @@
         "views/res_company_view.xml",
         "views/base_partner_merge_view.xml",
         "views/mail_activity_schedule_view.xml",
+        "views/mail_activity_view.xml",
         "views/res_partner_views.xml",
     ],
     "assets": {

--- a/base_ux/models/__init__.py
+++ b/base_ux/models/__init__.py
@@ -10,4 +10,5 @@ from . import res_company
 from . import mail_template
 from . import ir_actions_server
 from . import mail_activity
+from . import mail_activity_type
 from . import mail_activity_schedule

--- a/base_ux/models/mail_activity.py
+++ b/base_ux/models/mail_activity.py
@@ -2,11 +2,28 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class MailActivity(models.Model):
     _inherit = "mail.activity"
+
+    quick_activity_ids = fields.Many2many(
+        "mail.activity.type",
+        compute="_compute_quick_activity_ids",
+        help="IDs de los tipos de actividad más frecuentes para mostrar como badges.",
+    )
+
+    @api.depends("activity_type_id")
+    @api.depends_context("uid")
+    def _compute_quick_activity_ids(self):
+        """Las primeras N actividades por sequence, más el tipo ya seteado en la actividad.
+        Incluir el tipo actual es necesario al editar una actividad existente: si su tipo no
+        está entre los N sugeridos, el badge de la selección vigente no se renderizaría y
+        visualmente se perdería el valor guardado."""
+        quick_types = self.env["mail.activity.type"]._get_quick_activity_types()
+        for record in self:
+            record.quick_activity_ids = quick_types | record.activity_type_id
 
     @api.onchange("activity_type_id")
     def _onchange_activity_type_id(self):

--- a/base_ux/models/mail_activity_schedule.py
+++ b/base_ux/models/mail_activity_schedule.py
@@ -17,9 +17,6 @@ class MailActivitySchedule(models.TransientModel):
     @api.depends_context("uid")
     def _compute_quick_activity_ids(self):
         """Obtiene las primeras N actividades ordenadas por sequence."""
-        # Obtener el límite desde parámetros del sistema (por defecto 5)
-        limit_param = self.env["ir.config_parameter"].sudo().get_param("base_ux.activity_quick_badges", "5")
-        limit = int(limit_param)
-        quick_types = self.env["mail.activity.type"].search([], order="sequence, id", limit=limit)
+        quick_types = self.env["mail.activity.type"]._get_quick_activity_types()
         for record in self:
             record.quick_activity_ids = quick_types

--- a/base_ux/models/mail_activity_type.py
+++ b/base_ux/models/mail_activity_type.py
@@ -1,0 +1,17 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, models
+
+
+class MailActivityType(models.Model):
+    _inherit = "mail.activity.type"
+
+    @api.model
+    def _get_quick_activity_types(self):
+        """Devuelve las primeras N actividades ordenadas por sequence, para mostrar
+        como badges de acceso rápido. N sale del parámetro del sistema
+        base_ux.activity_quick_badges (por defecto 5)."""
+        limit_param = self.env["ir.config_parameter"].sudo().get_param("base_ux.activity_quick_badges", "5")
+        return self.search([], order="sequence, id", limit=int(limit_param))

--- a/base_ux/tests/__init__.py
+++ b/base_ux/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_base_partner_merge
+from . import test_mail_activity_quick_badges

--- a/base_ux/tests/test_mail_activity_quick_badges.py
+++ b/base_ux/tests/test_mail_activity_quick_badges.py
@@ -1,0 +1,47 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import TransactionCase
+
+
+class TestMailActivityQuickBadges(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env["ir.config_parameter"].set_param("base_ux.activity_quick_badges", "2")
+        cls.quick_types = cls.env["mail.activity.type"].create(
+            [
+                {"name": "Test quick 1", "sequence": -20},
+                {"name": "Test quick 2", "sequence": -19},
+            ]
+        )
+        cls.other_type = cls.env["mail.activity.type"].create({"name": "Test not quick", "sequence": 999})
+        cls.partner_model_id = cls.env["ir.model"]._get_id("res.partner")
+        cls.partner = cls.env["res.partner"].create({"name": "Test activity quick badges"})
+
+    def test_quick_types_limited_by_parameter(self):
+        self.assertEqual(self.env["mail.activity.type"]._get_quick_activity_types(), self.quick_types)
+
+    def test_schedule_wizard_shows_only_quick_types(self):
+        wizard = self.env["mail.activity.schedule"].create(
+            {
+                "res_model_id": self.partner_model_id,
+                "res_model": "res.partner",
+                "res_ids": str(self.partner.ids),
+            }
+        )
+        self.assertEqual(wizard.quick_activity_ids, self.quick_types)
+
+    def test_existing_activity_keeps_its_own_type(self):
+        """When editing an activity whose type is not among the quick ones, that type must
+        still be offered as a badge, otherwise the stored value is not rendered at all."""
+        activity = self.env["mail.activity"].create(
+            {
+                "res_model_id": self.partner_model_id,
+                "res_id": self.partner.id,
+                "activity_type_id": self.other_type.id,
+                "summary": "test",
+            }
+        )
+        self.assertEqual(activity.quick_activity_ids, self.quick_types | self.other_type)

--- a/base_ux/views/mail_activity_view.xml
+++ b/base_ux/views/mail_activity_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--
+        Mismo tratamiento que views/mail_activity_schedule_view.xml, pero del lado de
+        mail.activity: al EDITAR una actividad existente el botón "Editar" abre un
+        act_window sobre mail.activity (vista mail_activity_view_form_popup), no el
+        wizard mail.activity.schedule. Sin esta herencia esa vista mostraba los badges
+        de todos los tipos de actividad del sistema.
+
+        Configuración: mismo parámetro base_ux.activity_quick_badges (default: 5)
+    -->
+    <record id="mail_activity_view_form_popup_inherit" model="ir.ui.view">
+        <field name="name">mail.activity.view.form.popup.inherit</field>
+        <field name="model">mail.activity</field>
+        <field name="inherit_id" ref="mail.mail_activity_view_form_popup"/>
+        <field name="arch" type="xml">
+            <!-- Campo invisible para almacenar los IDs de actividades frecuentes -->
+            <xpath expr="//field[@name='activity_type_id'][@widget='selection_badge_icons']" position="before">
+                <field name="quick_activity_ids" invisible="1"/>
+            </xpath>
+
+            <!-- Modificar el campo original para limitar las opciones mostradas como badges -->
+            <xpath expr="//field[@name='activity_type_id'][@widget='selection_badge_icons']" position="attributes">
+                <attribute name="domain">[('id', 'in', quick_activity_ids)]</attribute>
+            </xpath>
+
+            <!-- Agregar selector completo debajo para búsqueda adicional -->
+            <xpath expr="//field[@name='activity_type_id'][@widget='selection_badge_icons']" position="after">
+                <div class="o_row mt-2" style="max-width: 400px;">
+                    <small class="text-muted">¿No encontrás el tipo que buscas?</small>
+                    <field name="activity_type_id"
+                           widget="many2one"
+                           placeholder="Buscar otro tipo de actividad..."
+                           options="{'no_create': True, 'no_open': True}"
+                           nolabel="1"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The quick activity badges customization was only applied to the creation flow, so the two dialogs behaved differently:

- **Scheduling a new activity** goes through the `mail.activity.schedule` wizard, whose view is already inherited in `views/mail_activity_schedule_view.xml` to limit the `selection_badge_icons` widget to the first N types and to offer a dropdown for the rest.
- **Editing an existing activity** opens an `act_window` on `mail.activity` (view `mail.mail_activity_view_form_popup`), which was not inherited at all. That dialog rendered a badge for every activity type in the system, which is unusable on a database with dozens of them.

Both dialogs are titled "Schedule Activity", which makes the difference easy to miss.

## Changes

- New `views/mail_activity_view.xml` inheriting `mail.mail_activity_view_form_popup` with the same domain on the badges widget plus the searchable fallback field. It also reaches `mail.mail_activity_view_form` (the full page view), which inherits from the popup one.
- The lookup of the suggested types moved to `mail.activity.type._get_quick_activity_types()`, shared by both models instead of duplicating the parameter handling.
- On `mail.activity` the computed field also includes the type currently set on the record. Without it, editing an activity whose type is not among the suggested ones would render no badge for the stored value.
- README entry reworded to describe the actual behaviour and its configuration parameter.

No behaviour change on the creation wizard.

## Test plan

New `tests/test_mail_activity_quick_badges.py` covers the three cases (parameter limit, wizard unchanged, existing activity keeping its own type). Run:

```
odoo-bin -d <db> -u base_ux --test-enable --test-tags /base_ux
```

Manually: on a database with more activity types than the configured limit (`base_ux.activity_quick_badges`, default 5), schedule an activity, save it, then hit *Edit* on it. Both dialogs must show the same short list of badges plus the search dropdown.