### PR TITLE
[IMP] base_import_ux: don't abort import on first bad number/date

### DIFF
--- a/base_import_ux/README.rst
+++ b/base_import_ux/README.rst
@@ -17,6 +17,12 @@ First Steps
  * Adds a "First Steps" section as the first block of General Settings, linking to a single panel that gathers the onboarding initial imports.
  * Shows each shortcut depending on the installed modules: Import Products (with ``product``), Import Customers / Import Vendors (with ``account_balance_import``, classified through the rank), Import Contacts (otherwise), and the Accounting setup guide (with ``account_balance_import``).
  * Recommends always using a fresh, clean template downloaded from the system to avoid errors carried by reused spreadsheets.
+ * Makes import errors less disruptive: a single badly-formatted number or date no longer cancels the whole import. Instead of raising on the first bad cell (which hides every other error and the offending row number), the value is deferred to the per-record ORM converter, which reports it **with its row number and expected-format hint**, accumulated together with every other field/record error in one pass.
+
+Technical notes
+===============
+
+ * ``base_import.import._parse_float_from_data`` / ``_parse_date_from_data`` are overridden to stop aborting the import on the first unparseable value (they used to ``raise ImportValidationError``). Only genuinely unexpected (non-``ValueError``) date failures are still raised.
 
 Installation
 ============

--- a/base_import_ux/__init__.py
+++ b/base_import_ux/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/base_import_ux/__manifest__.py
+++ b/base_import_ux/__manifest__.py
@@ -19,12 +19,12 @@
 ##############################################################################
 {
     "name": "First Steps",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.2.0",
     "category": "Tools",
     "sequence": 14,
     "summary": "Centralizes the onboarding initial imports in a single panel "
     "available from General Settings, showing each shortcut depending on the "
-    "installed modules",
+    "installed modules; and makes import error messages friendlier",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/base_import_ux/models/__init__.py
+++ b/base_import_ux/models/__init__.py
@@ -1,0 +1,1 @@
+from . import base_import

--- a/base_import_ux/models/base_import.py
+++ b/base_import_ux/models/base_import.py
@@ -1,0 +1,79 @@
+import datetime
+
+from odoo import api, fields, models
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT
+
+
+class BaseImport(models.TransientModel):
+    _inherit = "base_import.import"
+
+    @api.model
+    def _parse_float_from_data(self, data, index, name, options):
+        """Do not abort the whole import on the first badly-formatted number.
+
+        The standard method (see base_import/models/base_import.py) raises an
+        ``ImportValidationError`` as soon as one cell of a float/monetary column
+        cannot be parsed, which cancels the entire import and hides every other
+        error (and the offending row number). Here, when a value cannot be
+        parsed, we leave the original value untouched so the per-record ORM
+        converter reports it with its row number, together with every other
+        field/record error, in a single pass. Well-formed values are still
+        pre-cleaned (currency symbols, thousands separators) exactly as before.
+        """
+        for line in data:
+            raw = line[index] = line[index].strip()
+            if not line[index]:
+                continue
+            thousand_separator, decimal_separator = self._infer_separators(line[index], options)
+
+            if "E" in line[index] or "e" in line[index]:
+                tmp_value = line[index].replace(thousand_separator, ".")
+                try:
+                    tmp_value = f"{float(tmp_value):f}"
+                    line[index] = tmp_value
+                    thousand_separator = " "
+                except Exception:  # noqa: BLE001
+                    pass
+
+            line[index] = line[index].replace(thousand_separator, "").replace(decimal_separator, ".")
+            cleaned = self._remove_currency_symbol(line[index])
+            # Defer to the ORM converter instead of raising (which would cut the
+            # whole import): restore the raw value so the error is reported per
+            # row and accumulated with the rest.
+            line[index] = cleaned if cleaned is not False else raw
+
+    @api.model
+    def _parse_date_from_data(self, data, index, name, field_type, options):
+        """Same rationale as ``_parse_float_from_data`` for date/datetime columns.
+
+        A badly-formatted date no longer cancels the whole import: the raw value
+        is kept and the per-record ORM converter reports it (with its row number
+        and the expected format hint) alongside every other error. Genuinely
+        unexpected (non-``ValueError``) failures are still raised, as they signal
+        a real problem rather than user data.
+        """
+        dt = datetime.datetime
+        fmt = fields.Date.to_string if field_type == "date" else fields.Datetime.to_string
+        d_fmt = options.get("date_format") or DEFAULT_SERVER_DATE_FORMAT
+        dt_fmt = options.get("datetime_format") or DEFAULT_SERVER_DATETIME_FORMAT
+        for line in data:
+            if not line[index] or isinstance(line[index], datetime.date):
+                continue
+
+            raw = line[index]
+            v = line[index].strip()
+            try:
+                # first try parsing as a datetime if it's one
+                if dt_fmt and field_type == "datetime":
+                    try:
+                        line[index] = fmt(dt.strptime(v, dt_fmt))
+                        continue
+                    except ValueError:
+                        pass
+                # otherwise try parsing as a date whether it's a date
+                # or datetime
+                line[index] = fmt(dt.strptime(v, d_fmt))
+            except ValueError:
+                # Bad user-supplied date: keep the raw value and let the ORM
+                # converter report it per row instead of cutting the import.
+                line[index] = raw

--- a/base_import_ux/tests/__init__.py
+++ b/base_import_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_import_prevalidation

--- a/base_import_ux/tests/test_import_prevalidation.py
+++ b/base_import_ux/tests/test_import_prevalidation.py
@@ -1,0 +1,26 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestImportPreValidation(TransactionCase):
+    """A single badly-formatted number/date must NOT abort the whole import:
+    the raw value is kept so the per-record ORM converter reports it (with its
+    row) alongside every other error, instead of raising on the first bad cell.
+    """
+
+    def test_bad_float_does_not_abort_and_keeps_raw(self):
+        imp = self.env["base_import.import"]
+        data = [["100"], ["abc"], ["1.234,56"]]
+        # Must not raise (standard behaviour raised ImportValidationError here).
+        imp._parse_float_from_data(data, 0, "list_price", {})
+        self.assertEqual(data[0][0], "100")  # good value cleaned
+        self.assertEqual(data[1][0], "abc")  # bad value deferred to the ORM
+        # good value with thousands/decimal separators still normalised
+        self.assertEqual(data[2][0], "1234.56")
+
+    def test_bad_date_does_not_abort_and_keeps_raw(self):
+        imp = self.env["base_import.import"]
+        data = [["2024-01-15"], ["not-a-date"], ["2024-02-20"]]
+        imp._parse_date_from_data(data, 0, "date", "date", {})
+        self.assertEqual(data[0][0], "2024-01-15")
+        self.assertEqual(data[1][0], "not-a-date")  # bad value deferred, not cut
+        self.assertEqual(data[2][0], "2024-02-20")


### PR DESCRIPTION
## What

When importing a spreadsheet, a single badly-formatted number or date used to raise `ImportValidationError` and cancel the whole import, showing only that one error (e.g. `Column list_price contains incorrect values (value: abc)`) and hiding every other problem in the file — including the row where it happened.

This overrides `base_import.import._parse_float_from_data` and `_parse_date_from_data` in `base_import_ux` so an unparseable value is no longer fatal: the raw value is kept and deferred to the per-record ORM converter, which reports it **with its row number and expected-format hint**, accumulated together with every other field/record error in a single pass. Well-formed values are still pre-cleaned (currency symbols, thousands/decimal separators) exactly as before. Genuinely unexpected (non-`ValueError`) date failures are still raised.

## Why

Importing contacts/products with a typo in a numeric or date column meant seeing a single cryptic error, fixing it, re-running, and hitting the next one — one round-trip per error. Now the full list of issues shows at once, each located by row.

## Test plan

- `base_import_ux/tests/test_import_prevalidation.py`: asserts a bad float and a bad date no longer raise and keep the raw value for the ORM to report, while well-formed values are still normalised.
- Manual: import a products/contacts file with a bad number/date plus other field errors → all errors show together, each with its row, instead of the import stopping at the first bad cell.

Task 69257.
