### PR TITLE
[IMP] base_bg: backoff transient retries, runner memory cleanup and less cron churn

### DIFF
--- a/base_bg/__manifest__.py
+++ b/base_bg/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Base Background Jobs",
-    "version": "19.0.1.0.1",
+    "version": "19.0.1.1.0",
     "category": "Technical",
     "author": "ADHOC SA",
     "website": "https://www.adhoc.com.ar",

--- a/base_bg/models/base_bg.py
+++ b/base_bg/models/base_bg.py
@@ -109,14 +109,19 @@ class BaseBg(models.AbstractModel):
         """
         return self.bg_enqueue_records(self, method, threshold, *args, **kwargs)
 
-    def _trigger_crons(self):
+    def _trigger_crons(self, at=None):
         """
-        Trigger cron jobs to process enqueued background jobs
+        Trigger cron jobs to process enqueued background jobs.
+
+        :param at: optional datetime (or list of datetimes) at which the runner
+            should fire. Defaults to now; pass a future time to schedule a wake-up
+            when a backing-off job becomes eligible (creates an ir.cron.trigger row,
+            an INSERT that does not contend on the ir_cron row itself).
         """
         code = "_cron_run_enqueued_jobs("
         crons = self.env["ir.cron"].search([("code", "ilike", code)])
         for cron in crons:
-            cron._trigger()
+            cron._trigger(at=at)
 
     @api.model
     def is_serializable(self, value: Any) -> bool:

--- a/base_bg/models/base_bg.py
+++ b/base_bg/models/base_bg.py
@@ -111,12 +111,10 @@ class BaseBg(models.AbstractModel):
 
     def _trigger_crons(self, at=None):
         """
-        Trigger cron jobs to process enqueued background jobs.
+        Trigger the background-job runner cron(s).
 
-        :param at: optional datetime (or list of datetimes) at which the runner
-            should fire. Defaults to now; pass a future time to schedule a wake-up
-            when a backing-off job becomes eligible (creates an ir.cron.trigger row,
-            an INSERT that does not contend on the ir_cron row itself).
+        :param at: when the runner should fire (default now). Pass a future time to
+            schedule a wake-up for a backing-off job.
         """
         code = "_cron_run_enqueued_jobs("
         crons = self.env["ir.cron"].search([("code", "ilike", code)])

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -84,9 +84,7 @@ class BgJob(models.Model):
     transient_retry_count = fields.Integer(
         default=0,
         readonly=True,
-        help="Number of attempts lost to transient PostgreSQL contention (serialization / "
-        "deadlock / lock timeout); kept separate so a contention spike does not consume the "
-        "normal retry budget.",
+        help="Attempts lost to transient DB contention, counted separately from the normal retry budget.",
     )
     start_time = fields.Datetime(
         readonly=True,
@@ -122,7 +120,7 @@ class BgJob(models.Model):
     )
     next_retry_at = fields.Datetime(
         readonly=True,
-        help="Earliest moment this job may be picked up again after a transient (e.g. serialization) failure.",
+        help="Earliest time this job may be retried after a transient failure.",
     )
 
     @api.depends("start_time", "end_time")
@@ -186,10 +184,8 @@ class BgJob(models.Model):
         """
         Executes the job.
 
-        The method runs inside this transaction and is retried on transient
-        failures (see ``_handle_job_error``), so it may execute more than once
-        (at-least-once semantics). Job methods with non-transactional side effects
-        (emails, external API calls) should be idempotent or guard against repeats.
+        Retried on transient failures, so the method may run more than once
+        (at-least-once); side-effecting methods should be idempotent.
         """
         self.ensure_one()
         if self.state != "running":
@@ -236,13 +232,11 @@ class BgJob(models.Model):
 
     def finish(self):
         """
-        Mark the job as done and set the end time.
-        Also enqueue the next job in the batch if it exists.
+        Mark the job as done and enqueue the next job in the batch.
 
-        The cron is intentionally NOT triggered here: ``_cron_run_enqueued_jobs``
-        already re-triggers itself while eligible jobs remain, so triggering on
-        every single ``finish`` only piles redundant writes on ``ir_cron`` and
-        fuels serialization contention on the scheduler under load.
+        The cron is NOT triggered here: ``_cron_run_enqueued_jobs`` re-triggers
+        itself while eligible jobs remain, so triggering per finish only churns
+        ``ir_cron`` under load.
         """
         self.write(
             {
@@ -303,25 +297,15 @@ class BgJob(models.Model):
         """
         Handle a job execution error and decide whether to retry.
 
-        Transient PostgreSQL contention (serialization failure, deadlock, lock
-        timeout) raised while *running* the job is expected under concurrency and
-        clears on its own once the contending transactions drain. Such errors are
-        retried with exponential backoff + jitter using their OWN budget
-        (``transient_retry_count`` vs ``base_bg.transient_max_retries``), kept
-        separate from the normal ``retry_count`` / ``max_retries`` budget so a
-        contention spike never eats the retries meant for real errors. Every other
-        error keeps the original immediate-retry-then-fail behavior.
+        Transient DB contention (serialization / deadlock / lock timeout) is retried
+        with exponential backoff on its own budget (``transient_retry_count`` vs
+        ``base_bg.transient_max_retries``), separate from ``max_retries`` so a
+        contention spike does not consume the retries meant for real errors. Other
+        errors keep the immediate-retry-then-fail behavior. ``retry_count`` tracks
+        every attempt (for display); the non-transient budget is measured on
+        non-transient attempts.
 
-        ``retry_count`` counts every attempt (transient + non-transient) so callers
-        that display an attempt number stay accurate; the non-transient budget is
-        measured on non-transient attempts only.
-
-        (Concurrency failures while *acquiring* the job are handled earlier, in
-        ``_cron_run_enqueued_jobs``, before any work is done.)
-
-        :param error: The exception raised during job execution, or a message.
-        :return: True if the job was re-enqueued for another attempt, False if it
-            was failed permanently. Overrides rely on this to report retries.
+        :return: True if re-enqueued, False if failed permanently (overrides use this).
         """
         error_msg = str(error)
         self.retry_count += 1
@@ -337,9 +321,8 @@ class BgJob(models.Model):
                         "error_message": error_msg,
                     }
                 )
-                # Wake a runner exactly when the backoff elapses: a backing-off job
-                # is excluded from the self-retrigger, so without this it would idle
-                # until the next periodic cron tick.
+                # Wake a runner when the backoff elapses (a backing-off job is
+                # skipped by the self-retrigger, so nothing else would).
                 self.env["base.bg"].sudo()._trigger_crons(at=next_retry_at)
                 _logger.warning(
                     "Job %s hit transient contention, backing off %.1fs before retry #%d: %s",
@@ -375,14 +358,10 @@ class BgJob(models.Model):
     @api.model
     def _is_transient_error(self, error: Exception | str) -> bool:
         """
-        Whether ``error`` is a transient PostgreSQL concurrency failure
-        (serialization failure, deadlock or lock-not-available), safe to retry once
-        the contention clears. Reuses Odoo's canonical
-        ``PG_CONCURRENCY_EXCEPTIONS_TO_RETRY`` set.
-
-        Walks the exception chain (``__cause__`` and the implicit ``__context__``)
-        so a failure re-raised/wrapped one or more levels deep is still recognized.
-        A plain string (e.g. the "Job timed out" reaper message) is never transient.
+        Whether ``error`` is a transient PG concurrency failure, safe to retry.
+        Reuses Odoo's ``PG_CONCURRENCY_EXCEPTIONS_TO_RETRY`` and walks the
+        ``__cause__`` / ``__context__`` chain so a wrapped failure is still caught.
+        A plain string (the reaper's "Job timed out") is never transient.
         """
         seen: set[int] = set()
         exc = error if isinstance(error, BaseException) else None
@@ -406,9 +385,8 @@ class BgJob(models.Model):
     @api.model
     def _get_int_param(self, key: str, default: int) -> int:
         """
-        Read an integer system parameter, falling back to ``default`` (with a
-        warning) when the stored value is missing or not a valid integer, so a
-        fat-fingered parameter cannot crash the runner cron on every tick.
+        Read an int system parameter, falling back to ``default`` (with a warning)
+        on a missing or non-integer value, so a bad param cannot crash the runner.
         """
         value = self.env["ir.config_parameter"].sudo().get_param(key, default)
         try:
@@ -425,33 +403,25 @@ class BgJob(models.Model):
     @api.model
     def _get_max_concurrent_jobs(self) -> int:
         """
-        Best-effort throttle on how many jobs may be ``running`` at once. ``0``
-        (default) disables it, leaving concurrency untouched. Meant as a live
-        emergency valve: raise ``base_bg.max_concurrent_jobs`` to dampen a
-        contention storm without a deploy. It is best-effort, NOT a hard ceiling —
-        concurrent acquirers reading the same snapshot can overshoot it by up to the
-        number of runner workers.
+        Best-effort cap on how many jobs may be ``running`` at once; ``0`` (default)
+        disables it. A live emergency valve set via ``base_bg.max_concurrent_jobs``.
+        NOT a hard ceiling — concurrent acquirers can overshoot by up to the number
+        of runner workers.
         """
         return max(0, self._get_int_param("base_bg.max_concurrent_jobs", 0))
 
     @api.model
     def _get_cron_timeout(self) -> int:
-        """
-        The cron real-time limit in seconds (0 if unset), past which a still-
-        ``running`` job is treated as a dead-worker orphan.
-        """
+        """Cron real-time limit in seconds (0 if unset), past which a running job is a dead-worker orphan."""
         return tools.config.get("limit_time_real_cron") or 0
 
     @api.model
     def _can_acquire_job(self) -> bool:
         """
-        Best-effort admission control: whether a new job may start under the
-        ``base_bg.max_concurrent_jobs`` throttle (``0`` = disabled, the default).
-
-        Jobs stuck ``running`` past the cron timeout (dead-worker orphans, which the
-        monitor cron reaps) do not count toward the limit, so a couple of orphans
-        cannot saturate the cap and starve the queue. Best-effort, not a hard
-        ceiling: concurrent acquirers can overshoot by up to the number of workers.
+        Best-effort admission control under ``base_bg.max_concurrent_jobs``
+        (``0`` = disabled). Orphans stuck ``running`` past the cron timeout (reaped
+        by the monitor cron) do not count, so they cannot saturate the cap and
+        starve the queue.
         """
         cap = self._get_max_concurrent_jobs()
         if not cap:
@@ -526,11 +496,9 @@ class BgJob(models.Model):
         caller (_cron_run_enqueued_jobs) with a bounded retry, so it must not be logged
         as a "bad query" ERROR — hence log_exceptions=False.
 
-        Jobs still inside their ``next_retry_at`` backoff window are skipped. The
-        gate uses a Python-computed UTC timestamp (matching Odoo's naive-UTC storage
-        and ``fields.Datetime.now()``) rather than SQL ``NOW()``, whose result
-        depends on the session time zone. Concurrency throttling is a separate
-        concern handled by ``_can_acquire_job`` before this is called.
+        Backed-off jobs (``next_retry_at`` in the future) are skipped, using a Python
+        UTC timestamp rather than SQL ``NOW()`` (which is session-tz dependent).
+        Throttling is handled separately by ``_can_acquire_job``.
 
         :return: The next BgJob record to process, or an empty recordset if none available
         """
@@ -599,10 +567,8 @@ class BgJob(models.Model):
             return
 
         job.run()
-        # Trigger cron again only if there are more *eligible* jobs to process.
-        # Jobs waiting out their backoff window (next_retry_at in the future) must
-        # NOT keep the cron re-triggering, or a backing-off job would spin the
-        # scheduler in a tight loop and defeat the backoff.
+        # Re-trigger only if more *eligible* jobs remain: a backing-off job
+        # (next_retry_at in the future) must not spin the scheduler.
         if self._has_eligible_jobs():
             self.env["base.bg"].sudo()._trigger_crons()
 

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -78,7 +78,13 @@ class BgJob(models.Model):
     retry_count = fields.Integer(
         default=0,
         readonly=True,
-        help="Current number of retry attempts",
+        help="Total number of attempts made so far (transient + non-transient).",
+    )
+    serialization_retry_count = fields.Integer(
+        default=0,
+        readonly=True,
+        help="Number of attempts lost to transient serialization contention; kept separate "
+        "so a contention spike does not consume the normal retry budget.",
     )
     start_time = fields.Datetime(
         readonly=True,
@@ -176,7 +182,12 @@ class BgJob(models.Model):
 
     def run(self):
         """
-        Executes the job
+        Executes the job.
+
+        The method runs inside this transaction and is retried on transient
+        failures (see ``_handle_job_error``), so it may execute more than once
+        (at-least-once semantics). Job methods with non-transactional side effects
+        (emails, external API calls) should be idempotent or guard against repeats.
         """
         self.ensure_one()
         if self.state != "running":
@@ -215,6 +226,7 @@ class BgJob(models.Model):
             data.update(
                 {
                     "retry_count": 0,
+                    "serialization_retry_count": 0,
                     "error_message": False,
                 }
             )
@@ -253,6 +265,7 @@ class BgJob(models.Model):
                 "state": "failed",
                 "end_time": fields.Datetime.now(),
                 "error_message": error_message,
+                "next_retry_at": False,
             }
         )
         if notify:
@@ -269,6 +282,7 @@ class BgJob(models.Model):
                 "state": "canceled",
                 "cancel_time": fields.Datetime.now(),
                 "error_message": message,
+                "next_retry_at": False,
             }
         )
 
@@ -283,72 +297,96 @@ class BgJob(models.Model):
         records = self.env[self.model].browse(record_ids)
         return records
 
-    def _handle_job_error(self, error: Exception | str):
+    def _handle_job_error(self, error: Exception | str) -> bool:
         """
-        Handle job execution error.
+        Handle a job execution error and decide whether to retry.
 
         Transient PostgreSQL contention (serialization failures, SQLSTATE 40001)
         raised while *running* the job is expected under concurrency and clears on
         its own once the contending transactions drain. Such errors are retried
-        with exponential backoff + jitter and use a separate, larger retry budget
-        so a temporary contention spike never turns healthy jobs into permanent
-        failures. Every other error keeps the original immediate-retry-then-fail
-        behavior.
+        with exponential backoff + jitter using their OWN budget
+        (``serialization_retry_count`` vs ``base_bg.serialization_max_retries``),
+        kept separate from the normal ``retry_count`` / ``max_retries`` budget so a
+        contention spike never eats the retries meant for real errors. Every other
+        error keeps the original immediate-retry-then-fail behavior.
+
+        ``retry_count`` counts every attempt (transient + non-transient) so callers
+        that display an attempt number stay accurate; the non-transient budget is
+        measured on non-transient attempts only.
 
         (Serialization failures while *acquiring* the job are handled earlier, in
         ``_cron_run_enqueued_jobs``, before any work is done.)
 
         :param error: The exception raised during job execution, or a message.
+        :return: True if the job was re-enqueued for another attempt, False if it
+            was failed permanently. Overrides rely on this to report retries.
         """
         error_msg = str(error)
         self.retry_count += 1
         if self._is_transient_error(error):
-            if self.retry_count < self._get_serialization_max_retries():
-                delay = self._compute_backoff_delay(self.retry_count)
+            self.serialization_retry_count += 1
+            if self.serialization_retry_count < self._get_serialization_max_retries():
+                delay = self._compute_backoff_delay(self.serialization_retry_count)
+                next_retry_at = fields.Datetime.now() + timedelta(seconds=delay)
                 self.write(
                     {
                         "state": "enqueued",
-                        "next_retry_at": fields.Datetime.now() + timedelta(seconds=delay),
+                        "next_retry_at": next_retry_at,
                         "error_message": error_msg,
                     }
                 )
+                # Wake a runner exactly when the backoff elapses: a backing-off job
+                # is excluded from the self-retrigger, so without this it would idle
+                # until the next periodic cron tick.
+                self.env["base.bg"].sudo()._trigger_crons(at=next_retry_at)
                 _logger.warning(
                     "Job %s hit transient contention, backing off %.1fs before retry #%d: %s",
                     self.name,
                     delay,
-                    self.retry_count,
+                    self.serialization_retry_count,
                     error_msg,
                 )
-                return
+                return True
             self.fail(error_msg)
             self._get_next_jobs().cancel(message=_("Previous job in batch failed"))
             _logger.error(
                 "Job %s failed permanently after %d transient retries: %s",
                 self.name,
-                self.retry_count,
+                self.serialization_retry_count,
                 error_msg,
             )
-            return
+            return False
 
-        if self.retry_count < self.max_retries:
+        # Non-transient error: budget measured on non-transient attempts only.
+        if self.retry_count - self.serialization_retry_count < self.max_retries:
             self.enqueue()
             _logger.warning("Job %s failed, scheduling retry #%d: %s", self.name, self.retry_count, error_msg)
-        else:
-            # Max retries reached, mark as failed
-            self.fail(error_msg)
-            self._get_next_jobs().cancel(message=_("Previous job in batch failed"))
-            _logger.error("Job %s failed permanently: %s", self.name, error_msg)
+            return True
+        # Max retries reached, mark as failed
+        self.fail(error_msg)
+        self._get_next_jobs().cancel(message=_("Previous job in batch failed"))
+        _logger.error("Job %s failed permanently: %s", self.name, error_msg)
+        return False
 
     @api.model
     def _is_transient_error(self, error: Exception | str) -> bool:
         """
         Whether ``error`` is a transient PostgreSQL serialization failure
         (SQLSTATE 40001), safe to retry once the contention clears.
+
+        Walks the exception chain (``__cause__`` and the implicit ``__context__``)
+        so a serialization failure re-raised/wrapped one or more levels deep is
+        still recognized. A plain string (e.g. the "Job timed out" reaper message)
+        is never transient.
         """
-        for candidate in (error, getattr(error, "__cause__", None)):
-            if isinstance(candidate, psycopg2.Error) and getattr(candidate, "pgcode", None) == "40001":
+        seen: set[int] = set()
+        exc = error if isinstance(error, BaseException) else None
+        while exc is not None and id(exc) not in seen:
+            seen.add(id(exc))
+            if isinstance(exc, psycopg2.errors.SerializationFailure) or getattr(exc, "pgcode", None) == "40001":
                 return True
-        return "could not serialize access" in str(error)
+            exc = exc.__cause__ or exc.__context__
+        return False
 
     @api.model
     def _compute_backoff_delay(self, attempt: int) -> float:
@@ -357,23 +395,42 @@ class BgJob(models.Model):
         capped so a stuck job never waits absurdly long.
         """
         base, ceiling = 5, 300
-        delay = min(ceiling, base * (2 ** max(0, attempt - 1)))
+        # Clamp the exponent: beyond a handful of attempts the delay is already at
+        # the ceiling, so this only avoids building a pointless bignum if the
+        # serialization budget is configured very high.
+        delay = min(ceiling, base * (2 ** min(max(0, attempt - 1), 16)))
         return delay + random.uniform(0, delay * 0.25)
+
+    @api.model
+    def _get_int_param(self, key: str, default: int) -> int:
+        """
+        Read an integer system parameter, falling back to ``default`` (with a
+        warning) when the stored value is missing or not a valid integer, so a
+        fat-fingered parameter cannot crash the runner cron on every tick.
+        """
+        value = self.env["ir.config_parameter"].sudo().get_param(key, default)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            _logger.warning("Invalid value %r for system parameter %s; using default %s.", value, key, default)
+            return default
 
     @api.model
     def _get_serialization_max_retries(self) -> int:
         """Retry budget for transient serialization failures (separate from ``max_retries``)."""
-        return max(1, int(self.env["ir.config_parameter"].sudo().get_param("base_bg.serialization_max_retries", 10)))
+        return max(1, self._get_int_param("base_bg.serialization_max_retries", 10))
 
     @api.model
     def _get_max_concurrent_jobs(self) -> int:
         """
-        Global ceiling of jobs allowed in ``running`` at once. ``0`` (default)
-        disables the cap entirely, leaving concurrency untouched. Meant as an
-        emergency brake: raise it via the ``base_bg.max_concurrent_jobs`` system
-        parameter to throttle a contention storm without a deploy.
+        Best-effort throttle on how many jobs may be ``running`` at once. ``0``
+        (default) disables it, leaving concurrency untouched. Meant as a live
+        emergency valve: raise ``base_bg.max_concurrent_jobs`` to dampen a
+        contention storm without a deploy. It is best-effort, NOT a hard ceiling —
+        concurrent acquirers reading the same snapshot can overshoot it by up to the
+        number of runner workers.
         """
-        return max(0, int(self.env["ir.config_parameter"].sudo().get_param("base_bg.max_concurrent_jobs", 0)))
+        return max(0, self._get_int_param("base_bg.max_concurrent_jobs", 0))
 
     @api.model
     def _has_eligible_jobs(self) -> bool:
@@ -445,19 +502,31 @@ class BgJob(models.Model):
 
         :return: The next BgJob record to process, or an empty recordset if none available
         """
+        # Use a Python-computed UTC timestamp (matching Odoo's naive-UTC storage and
+        # fields.Datetime.now()) instead of SQL NOW(), whose result depends on the
+        # session time zone and would misjudge the backoff gate on non-UTC sessions.
         cap = self._get_max_concurrent_jobs()
+        params: dict = {"now": fields.Datetime.now()}
         cap_clause = ""
-        params: dict = {}
         if cap:
-            cap_clause = "AND (SELECT count(*) FROM bg_job WHERE state = 'running') < %(cap)s"
             params["cap"] = cap
+            timeout = tools.config.get("limit_time_real_cron") or 0
+            if timeout:
+                # Exclude rows stuck in 'running' past the cron timeout (a dead
+                # worker's orphan, which the monitor cron reaps) so a couple of
+                # orphans cannot saturate the cap and starve the queue.
+                params["running_cutoff"] = params["now"] - timedelta(seconds=timeout)
+                running_filter = "AND start_time > %(running_cutoff)s"
+            else:
+                running_filter = ""
+            cap_clause = f"AND (SELECT count(*) FROM bg_job WHERE state = 'running' {running_filter}) < %(cap)s"
         self.env.cr.execute(
             f"""
             WITH candidate AS (
                 SELECT id
                 FROM bg_job
                 WHERE state = 'enqueued'
-                  AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                  AND (next_retry_at IS NULL OR next_retry_at <= %(now)s)
                   {cap_clause}
                 ORDER BY priority, create_date, id
                 FOR UPDATE SKIP LOCKED
@@ -465,7 +534,7 @@ class BgJob(models.Model):
             )
             UPDATE bg_job j
             SET state = 'running',
-                start_time = NOW()
+                start_time = %(now)s
             FROM candidate
             WHERE j.id = candidate.id
             RETURNING j.id;

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -3,13 +3,13 @@
 # directory
 ##############################################################################
 import logging
+import random
 from datetime import timedelta
 
 import psycopg2
 from markupsafe import Markup
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError
-from odoo.fields import Domain
 
 _logger = logging.getLogger(__name__)
 
@@ -112,6 +112,10 @@ class BgJob(models.Model):
         readonly=True,
         help="Next job in the batch sequence",
     )
+    next_retry_at = fields.Datetime(
+        readonly=True,
+        help="Earliest moment this job may be picked up again after a transient (e.g. serialization) failure.",
+    )
 
     @api.depends("start_time", "end_time")
     def _compute_duration(self):
@@ -202,9 +206,10 @@ class BgJob(models.Model):
             self.env.cr.commit()  # pylint: disable=invalid-commit
 
     def enqueue(self, retry: bool = False):
-        """Mark the job as enqueued."""
+        """Mark the job as enqueued, clearing any pending backoff gate."""
         data: dict[str, str | int | bool] = {
             "state": "enqueued",
+            "next_retry_at": False,
         }
         if retry:
             data.update(
@@ -219,6 +224,11 @@ class BgJob(models.Model):
         """
         Mark the job as done and set the end time.
         Also enqueue the next job in the batch if it exists.
+
+        The cron is intentionally NOT triggered here: ``_cron_run_enqueued_jobs``
+        already re-triggers itself while eligible jobs remain, so triggering on
+        every single ``finish`` only piles redundant writes on ``ir_cron`` and
+        fuels serialization contention on the scheduler under load.
         """
         self.write(
             {
@@ -227,7 +237,6 @@ class BgJob(models.Model):
             }
         )
         self.filtered("next_job_id").mapped("next_job_id").enqueue()
-        self.env["base.bg"].sudo()._trigger_crons()
 
     def wait(self):
         """Mark the job as waiting for the previous job to complete."""
@@ -276,12 +285,51 @@ class BgJob(models.Model):
 
     def _handle_job_error(self, error: Exception | str):
         """
-        Handle job execution error
+        Handle job execution error.
 
-        :param error: The exception raised during job execution
+        Transient PostgreSQL contention (serialization failures, SQLSTATE 40001)
+        raised while *running* the job is expected under concurrency and clears on
+        its own once the contending transactions drain. Such errors are retried
+        with exponential backoff + jitter and use a separate, larger retry budget
+        so a temporary contention spike never turns healthy jobs into permanent
+        failures. Every other error keeps the original immediate-retry-then-fail
+        behavior.
+
+        (Serialization failures while *acquiring* the job are handled earlier, in
+        ``_cron_run_enqueued_jobs``, before any work is done.)
+
+        :param error: The exception raised during job execution, or a message.
         """
         error_msg = str(error)
         self.retry_count += 1
+        if self._is_transient_error(error):
+            if self.retry_count < self._get_serialization_max_retries():
+                delay = self._compute_backoff_delay(self.retry_count)
+                self.write(
+                    {
+                        "state": "enqueued",
+                        "next_retry_at": fields.Datetime.now() + timedelta(seconds=delay),
+                        "error_message": error_msg,
+                    }
+                )
+                _logger.warning(
+                    "Job %s hit transient contention, backing off %.1fs before retry #%d: %s",
+                    self.name,
+                    delay,
+                    self.retry_count,
+                    error_msg,
+                )
+                return
+            self.fail(error_msg)
+            self._get_next_jobs().cancel(message=_("Previous job in batch failed"))
+            _logger.error(
+                "Job %s failed permanently after %d transient retries: %s",
+                self.name,
+                self.retry_count,
+                error_msg,
+            )
+            return
+
         if self.retry_count < self.max_retries:
             self.enqueue()
             _logger.warning("Job %s failed, scheduling retry #%d: %s", self.name, self.retry_count, error_msg)
@@ -290,6 +338,57 @@ class BgJob(models.Model):
             self.fail(error_msg)
             self._get_next_jobs().cancel(message=_("Previous job in batch failed"))
             _logger.error("Job %s failed permanently: %s", self.name, error_msg)
+
+    @api.model
+    def _is_transient_error(self, error: Exception | str) -> bool:
+        """
+        Whether ``error`` is a transient PostgreSQL serialization failure
+        (SQLSTATE 40001), safe to retry once the contention clears.
+        """
+        for candidate in (error, getattr(error, "__cause__", None)):
+            if isinstance(candidate, psycopg2.Error) and getattr(candidate, "pgcode", None) == "40001":
+                return True
+        return "could not serialize access" in str(error)
+
+    @api.model
+    def _compute_backoff_delay(self, attempt: int) -> float:
+        """
+        Exponential backoff (seconds) with jitter for transient-error retries,
+        capped so a stuck job never waits absurdly long.
+        """
+        base, ceiling = 5, 300
+        delay = min(ceiling, base * (2 ** max(0, attempt - 1)))
+        return delay + random.uniform(0, delay * 0.25)
+
+    @api.model
+    def _get_serialization_max_retries(self) -> int:
+        """Retry budget for transient serialization failures (separate from ``max_retries``)."""
+        return max(1, int(self.env["ir.config_parameter"].sudo().get_param("base_bg.serialization_max_retries", 10)))
+
+    @api.model
+    def _get_max_concurrent_jobs(self) -> int:
+        """
+        Global ceiling of jobs allowed in ``running`` at once. ``0`` (default)
+        disables the cap entirely, leaving concurrency untouched. Meant as an
+        emergency brake: raise it via the ``base_bg.max_concurrent_jobs`` system
+        parameter to throttle a contention storm without a deploy.
+        """
+        return max(0, int(self.env["ir.config_parameter"].sudo().get_param("base_bg.max_concurrent_jobs", 0)))
+
+    @api.model
+    def _has_eligible_jobs(self) -> bool:
+        """Whether at least one enqueued job is past its backoff window."""
+        return bool(
+            self.search_count(
+                [
+                    ("state", "=", "enqueued"),
+                    "|",
+                    ("next_retry_at", "=", False),
+                    ("next_retry_at", "<=", fields.Datetime.now()),
+                ],
+                limit=1,
+            )
+        )
 
     def _notify_user(self, result: str):
         """
@@ -340,14 +439,26 @@ class BgJob(models.Model):
         caller (_cron_run_enqueued_jobs) with a bounded retry, so it must not be logged
         as a "bad query" ERROR — hence log_exceptions=False.
 
+        Jobs still inside their ``next_retry_at`` backoff window are skipped.
+        When ``base_bg.max_concurrent_jobs`` is set (> 0), jobs are only picked
+        while fewer than that many are already ``running``.
+
         :return: The next BgJob record to process, or an empty recordset if none available
         """
+        cap = self._get_max_concurrent_jobs()
+        cap_clause = ""
+        params: dict = {}
+        if cap:
+            cap_clause = "AND (SELECT count(*) FROM bg_job WHERE state = 'running') < %(cap)s"
+            params["cap"] = cap
         self.env.cr.execute(
-            """
+            f"""
             WITH candidate AS (
                 SELECT id
                 FROM bg_job
                 WHERE state = 'enqueued'
+                  AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+                  {cap_clause}
                 ORDER BY priority, create_date, id
                 FOR UPDATE SKIP LOCKED
                 LIMIT 1
@@ -359,6 +470,7 @@ class BgJob(models.Model):
             WHERE j.id = candidate.id
             RETURNING j.id;
             """,
+            params,
             log_exceptions=False,
         )
         row = self.env.cr.fetchone()
@@ -403,8 +515,11 @@ class BgJob(models.Model):
             return
 
         job.run()
-        # Trigger cron again if there are more jobs to process
-        if self.search_count(Domain("state", "=", "enqueued")):
+        # Trigger cron again only if there are more *eligible* jobs to process.
+        # Jobs waiting out their backoff window (next_retry_at in the future) must
+        # NOT keep the cron re-triggering, or a backing-off job would spin the
+        # scheduler in a tight loop and defeat the backoff.
+        if self._has_eligible_jobs():
             self.env["base.bg"].sudo()._trigger_crons()
 
     @api.model

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -186,6 +186,10 @@ class BgJob(models.Model):
 
         Retried on transient failures, so the method may run more than once
         (at-least-once); side-effecting methods should be idempotent.
+
+        The ORM cache is dropped after each job (``invalidate_all``): the runner
+        loops many jobs inside one long-lived cron process, so releasing each job's
+        cache flattens the runner's memory curve between jobs.
         """
         self.ensure_one()
         if self.state != "running":
@@ -209,8 +213,10 @@ class BgJob(models.Model):
                 self._notify_user(result)
 
             self.env.cr.commit()  # pylint: disable=invalid-commit
+            self.env.invalidate_all()
         except Exception as e:
             self.env.cr.rollback()  # pylint: disable=invalid-commit
+            self.env.invalidate_all()
             self._handle_job_error(e)
             self.env.cr.commit()  # pylint: disable=invalid-commit
 

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -401,38 +401,6 @@ class BgJob(models.Model):
         return max(1, self._get_int_param("base_bg.transient_max_retries", 10))
 
     @api.model
-    def _get_max_concurrent_jobs(self) -> int:
-        """
-        Best-effort cap on how many jobs may be ``running`` at once; ``0`` (default)
-        disables it. A live emergency valve set via ``base_bg.max_concurrent_jobs``.
-        NOT a hard ceiling — concurrent acquirers can overshoot by up to the number
-        of runner workers.
-        """
-        return max(0, self._get_int_param("base_bg.max_concurrent_jobs", 0))
-
-    @api.model
-    def _get_cron_timeout(self) -> int:
-        """Cron real-time limit in seconds (0 if unset), past which a running job is a dead-worker orphan."""
-        return tools.config.get("limit_time_real_cron") or 0
-
-    @api.model
-    def _can_acquire_job(self) -> bool:
-        """
-        Best-effort admission control under ``base_bg.max_concurrent_jobs``
-        (``0`` = disabled). Orphans stuck ``running`` past the cron timeout (reaped
-        by the monitor cron) do not count, so they cannot saturate the cap and
-        starve the queue.
-        """
-        cap = self._get_max_concurrent_jobs()
-        if not cap:
-            return True
-        domain = [("state", "=", "running")]
-        timeout = self._get_cron_timeout()
-        if timeout:
-            domain.append(("start_time", ">", fields.Datetime.now() - timedelta(seconds=timeout)))
-        return self.search_count(domain, limit=cap) < cap
-
-    @api.model
     def _has_eligible_jobs(self) -> bool:
         """Whether at least one enqueued job is past its backoff window."""
         return bool(
@@ -498,7 +466,6 @@ class BgJob(models.Model):
 
         Backed-off jobs (``next_retry_at`` in the future) are skipped, using a Python
         UTC timestamp rather than SQL ``NOW()`` (which is session-tz dependent).
-        Throttling is handled separately by ``_can_acquire_job``.
 
         :return: The next BgJob record to process, or an empty recordset if none available
         """
@@ -540,8 +507,6 @@ class BgJob(models.Model):
         in-process is safe and avoids the trigger storm caused by all workers
         surrendering at once and rescheduling each other.
         """
-        if not self._can_acquire_job():
-            return
         job = None
         for attempt in range(MAX_ACQUIRE_RETRIES):
             try:
@@ -575,7 +540,8 @@ class BgJob(models.Model):
     @api.model
     def _cron_check_running_jobs(self):
         """Check running background jobs honoring the cron timeout (seconds)."""
-        cutoff_date = fields.Datetime.now() - timedelta(seconds=self._get_cron_timeout())
+        timeout_seconds = tools.config.get("limit_time_real_cron") or 0
+        cutoff_date = fields.Datetime.now() - timedelta(seconds=timeout_seconds)
         jobs = self.search(
             [
                 ("start_time", "<", cutoff_date),

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -10,6 +10,7 @@ import psycopg2
 from markupsafe import Markup
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError
+from odoo.service.model import PG_CONCURRENCY_EXCEPTIONS_TO_RETRY
 
 _logger = logging.getLogger(__name__)
 
@@ -80,11 +81,12 @@ class BgJob(models.Model):
         readonly=True,
         help="Total number of attempts made so far (transient + non-transient).",
     )
-    serialization_retry_count = fields.Integer(
+    transient_retry_count = fields.Integer(
         default=0,
         readonly=True,
-        help="Number of attempts lost to transient serialization contention; kept separate "
-        "so a contention spike does not consume the normal retry budget.",
+        help="Number of attempts lost to transient PostgreSQL contention (serialization / "
+        "deadlock / lock timeout); kept separate so a contention spike does not consume the "
+        "normal retry budget.",
     )
     start_time = fields.Datetime(
         readonly=True,
@@ -226,7 +228,7 @@ class BgJob(models.Model):
             data.update(
                 {
                     "retry_count": 0,
-                    "serialization_retry_count": 0,
+                    "transient_retry_count": 0,
                     "error_message": False,
                 }
             )
@@ -301,12 +303,12 @@ class BgJob(models.Model):
         """
         Handle a job execution error and decide whether to retry.
 
-        Transient PostgreSQL contention (serialization failures, SQLSTATE 40001)
-        raised while *running* the job is expected under concurrency and clears on
-        its own once the contending transactions drain. Such errors are retried
-        with exponential backoff + jitter using their OWN budget
-        (``serialization_retry_count`` vs ``base_bg.serialization_max_retries``),
-        kept separate from the normal ``retry_count`` / ``max_retries`` budget so a
+        Transient PostgreSQL contention (serialization failure, deadlock, lock
+        timeout) raised while *running* the job is expected under concurrency and
+        clears on its own once the contending transactions drain. Such errors are
+        retried with exponential backoff + jitter using their OWN budget
+        (``transient_retry_count`` vs ``base_bg.transient_max_retries``), kept
+        separate from the normal ``retry_count`` / ``max_retries`` budget so a
         contention spike never eats the retries meant for real errors. Every other
         error keeps the original immediate-retry-then-fail behavior.
 
@@ -314,7 +316,7 @@ class BgJob(models.Model):
         that display an attempt number stay accurate; the non-transient budget is
         measured on non-transient attempts only.
 
-        (Serialization failures while *acquiring* the job are handled earlier, in
+        (Concurrency failures while *acquiring* the job are handled earlier, in
         ``_cron_run_enqueued_jobs``, before any work is done.)
 
         :param error: The exception raised during job execution, or a message.
@@ -324,9 +326,9 @@ class BgJob(models.Model):
         error_msg = str(error)
         self.retry_count += 1
         if self._is_transient_error(error):
-            self.serialization_retry_count += 1
-            if self.serialization_retry_count < self._get_serialization_max_retries():
-                delay = self._compute_backoff_delay(self.serialization_retry_count)
+            self.transient_retry_count += 1
+            if self.transient_retry_count < self._get_transient_max_retries():
+                delay = self._compute_backoff_delay(self.transient_retry_count)
                 next_retry_at = fields.Datetime.now() + timedelta(seconds=delay)
                 self.write(
                     {
@@ -343,47 +345,50 @@ class BgJob(models.Model):
                     "Job %s hit transient contention, backing off %.1fs before retry #%d: %s",
                     self.name,
                     delay,
-                    self.serialization_retry_count,
+                    self.transient_retry_count,
                     error_msg,
                 )
                 return True
-            self.fail(error_msg)
-            self._get_next_jobs().cancel(message=_("Previous job in batch failed"))
             _logger.error(
                 "Job %s failed permanently after %d transient retries: %s",
                 self.name,
-                self.serialization_retry_count,
+                self.transient_retry_count,
                 error_msg,
             )
-            return False
+            return self._give_up(error_msg)
 
         # Non-transient error: budget measured on non-transient attempts only.
-        if self.retry_count - self.serialization_retry_count < self.max_retries:
+        non_transient_attempts = self.retry_count - self.transient_retry_count
+        if non_transient_attempts < self.max_retries:
             self.enqueue()
             _logger.warning("Job %s failed, scheduling retry #%d: %s", self.name, self.retry_count, error_msg)
             return True
-        # Max retries reached, mark as failed
+        _logger.error("Job %s failed permanently: %s", self.name, error_msg)
+        return self._give_up(error_msg)
+
+    def _give_up(self, error_msg: str) -> bool:
+        """Fail this job permanently and cancel the rest of its batch. Returns False."""
         self.fail(error_msg)
         self._get_next_jobs().cancel(message=_("Previous job in batch failed"))
-        _logger.error("Job %s failed permanently: %s", self.name, error_msg)
         return False
 
     @api.model
     def _is_transient_error(self, error: Exception | str) -> bool:
         """
-        Whether ``error`` is a transient PostgreSQL serialization failure
-        (SQLSTATE 40001), safe to retry once the contention clears.
+        Whether ``error`` is a transient PostgreSQL concurrency failure
+        (serialization failure, deadlock or lock-not-available), safe to retry once
+        the contention clears. Reuses Odoo's canonical
+        ``PG_CONCURRENCY_EXCEPTIONS_TO_RETRY`` set.
 
         Walks the exception chain (``__cause__`` and the implicit ``__context__``)
-        so a serialization failure re-raised/wrapped one or more levels deep is
-        still recognized. A plain string (e.g. the "Job timed out" reaper message)
-        is never transient.
+        so a failure re-raised/wrapped one or more levels deep is still recognized.
+        A plain string (e.g. the "Job timed out" reaper message) is never transient.
         """
         seen: set[int] = set()
         exc = error if isinstance(error, BaseException) else None
         while exc is not None and id(exc) not in seen:
             seen.add(id(exc))
-            if isinstance(exc, psycopg2.errors.SerializationFailure) or getattr(exc, "pgcode", None) == "40001":
+            if isinstance(exc, PG_CONCURRENCY_EXCEPTIONS_TO_RETRY):
                 return True
             exc = exc.__cause__ or exc.__context__
         return False
@@ -391,14 +396,11 @@ class BgJob(models.Model):
     @api.model
     def _compute_backoff_delay(self, attempt: int) -> float:
         """
-        Exponential backoff (seconds) with jitter for transient-error retries,
-        capped so a stuck job never waits absurdly long.
+        Exponential backoff (seconds) with jitter, capped at 5 minutes. ``attempt``
+        is 1-based.
         """
-        base, ceiling = 5, 300
-        # Clamp the exponent: beyond a handful of attempts the delay is already at
-        # the ceiling, so this only avoids building a pointless bignum if the
-        # serialization budget is configured very high.
-        delay = min(ceiling, base * (2 ** min(max(0, attempt - 1), 16)))
+        base, ceiling, exp_cap = 5, 300, 8
+        delay = min(ceiling, base * 2 ** min(attempt - 1, exp_cap))
         return delay + random.uniform(0, delay * 0.25)
 
     @api.model
@@ -416,9 +418,9 @@ class BgJob(models.Model):
             return default
 
     @api.model
-    def _get_serialization_max_retries(self) -> int:
-        """Retry budget for transient serialization failures (separate from ``max_retries``)."""
-        return max(1, self._get_int_param("base_bg.serialization_max_retries", 10))
+    def _get_transient_max_retries(self) -> int:
+        """Retry budget for transient concurrency failures (separate from ``max_retries``)."""
+        return max(1, self._get_int_param("base_bg.transient_max_retries", 10))
 
     @api.model
     def _get_max_concurrent_jobs(self) -> int:
@@ -431,6 +433,34 @@ class BgJob(models.Model):
         number of runner workers.
         """
         return max(0, self._get_int_param("base_bg.max_concurrent_jobs", 0))
+
+    @api.model
+    def _get_cron_timeout(self) -> int:
+        """
+        The cron real-time limit in seconds (0 if unset), past which a still-
+        ``running`` job is treated as a dead-worker orphan.
+        """
+        return tools.config.get("limit_time_real_cron") or 0
+
+    @api.model
+    def _can_acquire_job(self) -> bool:
+        """
+        Best-effort admission control: whether a new job may start under the
+        ``base_bg.max_concurrent_jobs`` throttle (``0`` = disabled, the default).
+
+        Jobs stuck ``running`` past the cron timeout (dead-worker orphans, which the
+        monitor cron reaps) do not count toward the limit, so a couple of orphans
+        cannot saturate the cap and starve the queue. Best-effort, not a hard
+        ceiling: concurrent acquirers can overshoot by up to the number of workers.
+        """
+        cap = self._get_max_concurrent_jobs()
+        if not cap:
+            return True
+        domain = [("state", "=", "running")]
+        timeout = self._get_cron_timeout()
+        if timeout:
+            domain.append(("start_time", ">", fields.Datetime.now() - timedelta(seconds=timeout)))
+        return self.search_count(domain, limit=cap) < cap
 
     @api.model
     def _has_eligible_jobs(self) -> bool:
@@ -496,38 +526,21 @@ class BgJob(models.Model):
         caller (_cron_run_enqueued_jobs) with a bounded retry, so it must not be logged
         as a "bad query" ERROR — hence log_exceptions=False.
 
-        Jobs still inside their ``next_retry_at`` backoff window are skipped.
-        When ``base_bg.max_concurrent_jobs`` is set (> 0), jobs are only picked
-        while fewer than that many are already ``running``.
+        Jobs still inside their ``next_retry_at`` backoff window are skipped. The
+        gate uses a Python-computed UTC timestamp (matching Odoo's naive-UTC storage
+        and ``fields.Datetime.now()``) rather than SQL ``NOW()``, whose result
+        depends on the session time zone. Concurrency throttling is a separate
+        concern handled by ``_can_acquire_job`` before this is called.
 
         :return: The next BgJob record to process, or an empty recordset if none available
         """
-        # Use a Python-computed UTC timestamp (matching Odoo's naive-UTC storage and
-        # fields.Datetime.now()) instead of SQL NOW(), whose result depends on the
-        # session time zone and would misjudge the backoff gate on non-UTC sessions.
-        cap = self._get_max_concurrent_jobs()
-        params: dict = {"now": fields.Datetime.now()}
-        cap_clause = ""
-        if cap:
-            params["cap"] = cap
-            timeout = tools.config.get("limit_time_real_cron") or 0
-            if timeout:
-                # Exclude rows stuck in 'running' past the cron timeout (a dead
-                # worker's orphan, which the monitor cron reaps) so a couple of
-                # orphans cannot saturate the cap and starve the queue.
-                params["running_cutoff"] = params["now"] - timedelta(seconds=timeout)
-                running_filter = "AND start_time > %(running_cutoff)s"
-            else:
-                running_filter = ""
-            cap_clause = f"AND (SELECT count(*) FROM bg_job WHERE state = 'running' {running_filter}) < %(cap)s"
         self.env.cr.execute(
-            f"""
+            """
             WITH candidate AS (
                 SELECT id
                 FROM bg_job
                 WHERE state = 'enqueued'
                   AND (next_retry_at IS NULL OR next_retry_at <= %(now)s)
-                  {cap_clause}
                 ORDER BY priority, create_date, id
                 FOR UPDATE SKIP LOCKED
                 LIMIT 1
@@ -539,7 +552,7 @@ class BgJob(models.Model):
             WHERE j.id = candidate.id
             RETURNING j.id;
             """,
-            params,
+            {"now": fields.Datetime.now()},
             log_exceptions=False,
         )
         row = self.env.cr.fetchone()
@@ -559,6 +572,8 @@ class BgJob(models.Model):
         in-process is safe and avoids the trigger storm caused by all workers
         surrendering at once and rescheduling each other.
         """
+        if not self._can_acquire_job():
+            return
         job = None
         for attempt in range(MAX_ACQUIRE_RETRIES):
             try:
@@ -594,8 +609,7 @@ class BgJob(models.Model):
     @api.model
     def _cron_check_running_jobs(self):
         """Check running background jobs honoring the cron timeout (seconds)."""
-        timeout_seconds = tools.config.get("limit_time_real_cron") or 0
-        cutoff_date = fields.Datetime.now() - timedelta(seconds=timeout_seconds)
+        cutoff_date = fields.Datetime.now() - timedelta(seconds=self._get_cron_timeout())
         jobs = self.search(
             [
                 ("start_time", "<", cutoff_date),

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -630,7 +630,7 @@ class TestBgJob(TransactionCase):
         self.assertTrue(requeued)
         job.invalidate_recordset()
         self.assertEqual(job.state, "enqueued")
-        self.assertEqual(job.serialization_retry_count, 1)
+        self.assertEqual(job.transient_retry_count, 1)
         self.assertEqual(job.retry_count, 1)
         self.assertTrue(job.next_retry_at, "A backoff gate must be set for transient errors")
         self.assertGreater(job.next_retry_at, fields.Datetime.now())
@@ -641,7 +641,7 @@ class TestBgJob(TransactionCase):
     def test_transient_error_does_not_consume_normal_retry_budget(self):
         """Serialization retries use their own budget (default 10), not max_retries (3)."""
         job = self._create_job(
-            name="Persistent Transient", state="running", max_retries=3, retry_count=5, serialization_retry_count=5
+            name="Persistent Transient", state="running", max_retries=3, retry_count=5, transient_retry_count=5
         )
         with patch("odoo.addons.base_bg.models.bg_job._logger.warning"), patch.object(
             type(self.env["base.bg"]), "_trigger_crons"
@@ -651,12 +651,12 @@ class TestBgJob(TransactionCase):
         self.assertTrue(requeued)
         job.invalidate_recordset()
         self.assertEqual(job.state, "enqueued")  # not failed despite retry_count > max_retries
-        self.assertEqual(job.serialization_retry_count, 6)
+        self.assertEqual(job.transient_retry_count, 6)
 
     def test_transient_error_fails_after_serialization_cap(self):
         """Once the serialization retry budget is exhausted, the job fails permanently."""
-        self._set_param("base_bg.serialization_max_retries", "3")
-        job = self._create_job(name="Exhausted Transient", state="running", retry_count=2, serialization_retry_count=2)
+        self._set_param("base_bg.transient_max_retries", "3")
+        job = self._create_job(name="Exhausted Transient", state="running", retry_count=2, transient_retry_count=2)
         with patch("odoo.addons.base_bg.models.bg_job._logger.error"):
             requeued = job._handle_job_error(self._serialization_error())
 
@@ -674,12 +674,12 @@ class TestBgJob(TransactionCase):
         job.invalidate_recordset()
         self.assertEqual(job.state, "enqueued")
         self.assertEqual(job.retry_count, 1)
-        self.assertEqual(job.serialization_retry_count, 0)
+        self.assertEqual(job.transient_retry_count, 0)
         self.assertFalse(job.next_retry_at, "Non-transient retries must not set a backoff gate")
 
     def test_transient_retries_do_not_starve_real_error_budget(self):
         """A job that burned transient retries still gets its full non-transient budget."""
-        job = self._create_job(name="Mixed", state="running", max_retries=3, retry_count=4, serialization_retry_count=4)
+        job = self._create_job(name="Mixed", state="running", max_retries=3, retry_count=4, transient_retry_count=4)
         with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
             requeued = job._handle_job_error("A genuine business error")
 
@@ -691,12 +691,12 @@ class TestBgJob(TransactionCase):
     def test_malformed_int_params_fall_back_to_default(self):
         """A non-integer system parameter must not crash the runner; it falls back to the default."""
         self._set_param("base_bg.max_concurrent_jobs", "not-a-number")
-        self._set_param("base_bg.serialization_max_retries", "")
+        self._set_param("base_bg.transient_max_retries", "")
         with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
             self.assertEqual(self.BgJob._get_max_concurrent_jobs(), 0)
-            self.assertEqual(self.BgJob._get_serialization_max_retries(), 10)
-            # The picker must not raise with a malformed cap param.
-            self.BgJob._get_next_job()
+            self.assertEqual(self.BgJob._get_transient_max_retries(), 10)
+            # Admission control must not raise with a malformed cap param.
+            self.assertTrue(self.BgJob._can_acquire_job())
 
     def test_fail_and_cancel_clear_backoff_gate(self):
         """fail() and cancel() clear next_retry_at so no stale gate lingers on the row."""
@@ -721,34 +721,31 @@ class TestBgJob(TransactionCase):
         eligible = self._create_job(name="Ready", state="enqueued")
         self.assertEqual(self.BgJob._get_next_job(), eligible)
 
-    def test_get_next_job_respects_concurrency_cap(self):
-        """With the cap set and already reached by a fresh running job, no new job is picked."""
+    def test_admission_blocks_when_cap_reached(self):
+        """With the cap set and already reached by a fresh running job, admission is denied."""
         self.BgJob.search([("state", "in", ["enqueued", "running"])]).write({"state": "canceled"})
         self._set_param("base_bg.max_concurrent_jobs", "1")
         self._set_cron_timeout(5)
         self._create_job(name="Already Running", state="running", start_time=fields.Datetime.now())
-        self._create_job(name="Waiting For Slot", state="enqueued")
 
-        self.assertEqual(self.BgJob._get_next_job(), self.env["bg.job"])
+        self.assertFalse(self.BgJob._can_acquire_job())
 
-    def test_concurrency_cap_ignores_orphaned_running_jobs(self):
+    def test_admission_ignores_orphaned_running_jobs(self):
         """A job stuck in 'running' past the cron timeout must not consume the cap."""
         self.BgJob.search([("state", "in", ["enqueued", "running"])]).write({"state": "canceled"})
         self._set_param("base_bg.max_concurrent_jobs", "1")
         self._set_cron_timeout(5)  # limit_time_real_cron = 300s
         stale = fields.Datetime.now() - timedelta(hours=1)
         self._create_job(name="Orphan", state="running", start_time=stale)
-        job = self._create_job(name="Fresh", state="enqueued")
 
-        self.assertEqual(self.BgJob._get_next_job(), job)
+        self.assertTrue(self.BgJob._can_acquire_job(), "an orphan past the timeout must not saturate the cap")
 
-    def test_concurrency_cap_disabled_by_default(self):
-        """With the default parameter (0) the cap is off and jobs run normally."""
+    def test_admission_open_when_cap_disabled(self):
+        """With the default parameter (0) the cap is off and admission is always granted."""
         self.BgJob.search([("state", "in", ["enqueued", "running"])]).write({"state": "canceled"})
         self._create_job(name="Running A", state="running", start_time=fields.Datetime.now())
-        job = self._create_job(name="Should Still Run", state="enqueued")
 
-        self.assertEqual(self.BgJob._get_next_job(), job)
+        self.assertTrue(self.BgJob._can_acquire_job())
 
     def test_finish_does_not_trigger_cron(self):
         """finish() must not hammer the cron on every completed job."""

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -568,3 +568,100 @@ class TestBgJob(TransactionCase):
         # Not retried, and the transaction is rolled back before propagating.
         self.assertEqual(mock_get.call_count, 1)
         mock_rollback.assert_called_once()
+
+    # --- Serialization backoff, eligibility and concurrency cap -------------
+
+    def test_is_transient_error_detects_serialization(self):
+        """Serialization failures (SQLSTATE 40001) must be classified as transient."""
+        job = self._create_job()
+
+        class _FakeSerializationError(psycopg2.Error):
+            pgcode = "40001"
+
+        # By message (fallback path) and by pgcode on a psycopg2 error
+        self.assertTrue(job._is_transient_error("could not serialize access due to concurrent update"))
+        self.assertTrue(job._is_transient_error(_FakeSerializationError()))
+        # Unrelated errors are not transient
+        self.assertFalse(job._is_transient_error("Some other failure"))
+        self.assertFalse(job._is_transient_error(ValueError("boom")))
+
+    def test_transient_error_backs_off_and_reenqueues(self):
+        """A serialization failure re-enqueues with a future backoff gate instead of failing."""
+        job = self._create_job(name="Transient Job", state="running", max_retries=3)
+        with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
+            job._handle_job_error("could not serialize access due to concurrent update")
+
+        job.invalidate_recordset()
+        self.assertEqual(job.state, "enqueued")
+        self.assertEqual(job.retry_count, 1)
+        self.assertTrue(job.next_retry_at, "A backoff gate must be set for transient errors")
+        self.assertGreater(job.next_retry_at, fields.Datetime.now())
+
+    def test_transient_error_does_not_consume_normal_retry_budget(self):
+        """Serialization retries use the larger serialization budget, not max_retries."""
+        # max_retries is 3, but a transient error past it must still keep retrying.
+        job = self._create_job(name="Persistent Transient", state="running", max_retries=3, retry_count=5)
+        with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
+            job._handle_job_error("could not serialize access due to concurrent update")
+
+        job.invalidate_recordset()
+        self.assertEqual(job.state, "enqueued")  # not failed despite retry_count > max_retries
+        self.assertEqual(job.retry_count, 6)
+
+    def test_transient_error_fails_after_serialization_cap(self):
+        """Once the serialization retry cap is reached, the job fails permanently."""
+        self.env["ir.config_parameter"].sudo().set_param("base_bg.serialization_max_retries", "3")
+        job = self._create_job(name="Exhausted Transient", state="running", retry_count=2)
+        with patch("odoo.addons.base_bg.models.bg_job._logger.error"):
+            job._handle_job_error("could not serialize access due to concurrent update")
+
+        job.invalidate_recordset()
+        self.assertEqual(job.state, "failed")
+
+    def test_non_transient_error_keeps_immediate_retry(self):
+        """Non-serialization errors keep the original retry-then-fail behavior, no backoff gate."""
+        job = self._create_job(name="Real Error Job", state="running", max_retries=2)
+        with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
+            job._handle_job_error("Some real failure")
+
+        job.invalidate_recordset()
+        self.assertEqual(job.state, "enqueued")
+        self.assertEqual(job.retry_count, 1)
+        self.assertFalse(job.next_retry_at, "Non-transient retries must not set a backoff gate")
+
+    def test_get_next_job_skips_jobs_in_backoff(self):
+        """Jobs whose backoff window is still in the future are not picked up."""
+        self.BgJob.search([("state", "=", "enqueued")]).write({"state": "canceled"})
+        future = fields.Datetime.now() + timedelta(minutes=10)
+        self._create_job(name="Backing Off", state="enqueued", next_retry_at=future)
+        self.assertEqual(self.BgJob._get_next_job(), self.env["bg.job"])
+
+        eligible = self._create_job(name="Ready", state="enqueued")
+        self.assertEqual(self.BgJob._get_next_job(), eligible)
+
+    def test_get_next_job_respects_concurrency_cap(self):
+        """With the cap set and already reached, no new job is picked."""
+        self.BgJob.search([("state", "in", ["enqueued", "running"])]).write({"state": "canceled"})
+        self.env["ir.config_parameter"].sudo().set_param("base_bg.max_concurrent_jobs", "1")
+        self._create_job(name="Already Running", state="running", start_time=fields.Datetime.now())
+        self._create_job(name="Waiting For Slot", state="enqueued")
+
+        self.assertEqual(self.BgJob._get_next_job(), self.env["bg.job"])
+
+    def test_concurrency_cap_disabled_by_default(self):
+        """With the default parameter (0) the cap is off and jobs run normally."""
+        self.BgJob.search([("state", "in", ["enqueued", "running"])]).write({"state": "canceled"})
+        self._create_job(name="Running A", state="running", start_time=fields.Datetime.now())
+        job = self._create_job(name="Should Still Run", state="enqueued")
+
+        self.assertEqual(self.BgJob._get_next_job(), job)
+
+    def test_finish_does_not_trigger_cron(self):
+        """finish() must not hammer the cron on every completed job."""
+        job = self._create_job(name="Finish No Trigger", state="running")
+        with patch.object(type(self.env["base.bg"]), "_trigger_crons") as mock_trigger:
+            job.finish()
+
+        job.invalidate_recordset()
+        self.assertEqual(job.state, "done")
+        mock_trigger.assert_not_called()

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -688,15 +688,11 @@ class TestBgJob(TransactionCase):
         self.assertEqual(job.state, "enqueued")
         self.assertEqual(job.retry_count, 5)  # non-transient attempts = 5 - 4 = 1 < max_retries(3)
 
-    def test_malformed_int_params_fall_back_to_default(self):
+    def test_malformed_int_param_falls_back_to_default(self):
         """A non-integer system parameter must not crash the runner; it falls back to the default."""
-        self._set_param("base_bg.max_concurrent_jobs", "not-a-number")
-        self._set_param("base_bg.transient_max_retries", "")
+        self._set_param("base_bg.transient_max_retries", "not-a-number")
         with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
-            self.assertEqual(self.BgJob._get_max_concurrent_jobs(), 0)
             self.assertEqual(self.BgJob._get_transient_max_retries(), 10)
-            # Admission control must not raise with a malformed cap param.
-            self.assertTrue(self.BgJob._can_acquire_job())
 
     def test_fail_and_cancel_clear_backoff_gate(self):
         """fail() and cancel() clear next_retry_at so no stale gate lingers on the row."""
@@ -720,32 +716,6 @@ class TestBgJob(TransactionCase):
 
         eligible = self._create_job(name="Ready", state="enqueued")
         self.assertEqual(self.BgJob._get_next_job(), eligible)
-
-    def test_admission_blocks_when_cap_reached(self):
-        """With the cap set and already reached by a fresh running job, admission is denied."""
-        self.BgJob.search([("state", "in", ["enqueued", "running"])]).write({"state": "canceled"})
-        self._set_param("base_bg.max_concurrent_jobs", "1")
-        self._set_cron_timeout(5)
-        self._create_job(name="Already Running", state="running", start_time=fields.Datetime.now())
-
-        self.assertFalse(self.BgJob._can_acquire_job())
-
-    def test_admission_ignores_orphaned_running_jobs(self):
-        """A job stuck in 'running' past the cron timeout must not consume the cap."""
-        self.BgJob.search([("state", "in", ["enqueued", "running"])]).write({"state": "canceled"})
-        self._set_param("base_bg.max_concurrent_jobs", "1")
-        self._set_cron_timeout(5)  # limit_time_real_cron = 300s
-        stale = fields.Datetime.now() - timedelta(hours=1)
-        self._create_job(name="Orphan", state="running", start_time=stale)
-
-        self.assertTrue(self.BgJob._can_acquire_job(), "an orphan past the timeout must not saturate the cap")
-
-    def test_admission_open_when_cap_disabled(self):
-        """With the default parameter (0) the cap is off and admission is always granted."""
-        self.BgJob.search([("state", "in", ["enqueued", "running"])]).write({"state": "canceled"})
-        self._create_job(name="Running A", state="running", start_time=fields.Datetime.now())
-
-        self.assertTrue(self.BgJob._can_acquire_job())
 
     def test_finish_does_not_trigger_cron(self):
         """finish() must not hammer the cron on every completed job."""

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -571,50 +571,96 @@ class TestBgJob(TransactionCase):
 
     # --- Serialization backoff, eligibility and concurrency cap -------------
 
+    def _serialization_error(self):
+        """Build a real psycopg2 serialization failure (SQLSTATE 40001)."""
+        return psycopg2.errors.SerializationFailure("could not serialize access due to concurrent update")
+
+    def _set_param(self, key, value):
+        """Set a system parameter and restore its prior state on cleanup.
+
+        ir.config_parameter is cached in a process-global ormcache that survives
+        the TransactionCase rollback, so tests must undo their own set_param.
+        """
+        icp = self.env["ir.config_parameter"].sudo()
+        original = icp.get_param(key, False)
+
+        def _restore():
+            if original is False:
+                param = icp.search([("key", "=", key)])
+                if param:
+                    param.unlink()
+            else:
+                icp.set_param(key, original)
+
+        self.addCleanup(_restore)
+        icp.set_param(key, value)
+
     def test_is_transient_error_detects_serialization(self):
-        """Serialization failures (SQLSTATE 40001) must be classified as transient."""
+        """40001 failures are transient whether raw, chained via __cause__, or via __context__."""
         job = self._create_job()
-
-        class _FakeSerializationError(psycopg2.Error):
-            pgcode = "40001"
-
-        # By message (fallback path) and by pgcode on a psycopg2 error
-        self.assertTrue(job._is_transient_error("could not serialize access due to concurrent update"))
-        self.assertTrue(job._is_transient_error(_FakeSerializationError()))
-        # Unrelated errors are not transient
-        self.assertFalse(job._is_transient_error("Some other failure"))
+        self.assertTrue(job._is_transient_error(self._serialization_error()))
+        # Wrapped with an explicit cause (raise ... from) ...
+        try:
+            try:
+                raise self._serialization_error()
+            except psycopg2.errors.SerializationFailure as exc:
+                raise ValueError("wrapped") from exc
+        except ValueError as chained:
+            self.assertTrue(job._is_transient_error(chained))
+        # ... and with implicit chaining (__context__)
+        try:
+            try:
+                raise self._serialization_error()
+            except psycopg2.errors.SerializationFailure:
+                raise ValueError("implicitly chained")
+        except ValueError as chained_ctx:
+            self.assertTrue(job._is_transient_error(chained_ctx))
+        # Unrelated exceptions, and plain strings that merely contain the phrase, are NOT transient
         self.assertFalse(job._is_transient_error(ValueError("boom")))
+        self.assertFalse(job._is_transient_error("could not serialize access due to concurrent update"))
 
     def test_transient_error_backs_off_and_reenqueues(self):
-        """A serialization failure re-enqueues with a future backoff gate instead of failing."""
+        """A serialization failure re-enqueues with a future backoff gate and schedules a wake-up."""
         job = self._create_job(name="Transient Job", state="running", max_retries=3)
-        with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
-            job._handle_job_error("could not serialize access due to concurrent update")
+        with patch("odoo.addons.base_bg.models.bg_job._logger.warning"), patch.object(
+            type(self.env["base.bg"]), "_trigger_crons"
+        ) as mock_trigger:
+            requeued = job._handle_job_error(self._serialization_error())
 
+        self.assertTrue(requeued)
         job.invalidate_recordset()
         self.assertEqual(job.state, "enqueued")
+        self.assertEqual(job.serialization_retry_count, 1)
         self.assertEqual(job.retry_count, 1)
         self.assertTrue(job.next_retry_at, "A backoff gate must be set for transient errors")
         self.assertGreater(job.next_retry_at, fields.Datetime.now())
+        # A wake-up is scheduled for when the backoff elapses.
+        mock_trigger.assert_called_once()
+        self.assertIn("at", mock_trigger.call_args.kwargs)
 
     def test_transient_error_does_not_consume_normal_retry_budget(self):
-        """Serialization retries use the larger serialization budget, not max_retries."""
-        # max_retries is 3, but a transient error past it must still keep retrying.
-        job = self._create_job(name="Persistent Transient", state="running", max_retries=3, retry_count=5)
-        with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
-            job._handle_job_error("could not serialize access due to concurrent update")
+        """Serialization retries use their own budget (default 10), not max_retries (3)."""
+        job = self._create_job(
+            name="Persistent Transient", state="running", max_retries=3, retry_count=5, serialization_retry_count=5
+        )
+        with patch("odoo.addons.base_bg.models.bg_job._logger.warning"), patch.object(
+            type(self.env["base.bg"]), "_trigger_crons"
+        ):
+            requeued = job._handle_job_error(self._serialization_error())
 
+        self.assertTrue(requeued)
         job.invalidate_recordset()
         self.assertEqual(job.state, "enqueued")  # not failed despite retry_count > max_retries
-        self.assertEqual(job.retry_count, 6)
+        self.assertEqual(job.serialization_retry_count, 6)
 
     def test_transient_error_fails_after_serialization_cap(self):
-        """Once the serialization retry cap is reached, the job fails permanently."""
-        self.env["ir.config_parameter"].sudo().set_param("base_bg.serialization_max_retries", "3")
-        job = self._create_job(name="Exhausted Transient", state="running", retry_count=2)
+        """Once the serialization retry budget is exhausted, the job fails permanently."""
+        self._set_param("base_bg.serialization_max_retries", "3")
+        job = self._create_job(name="Exhausted Transient", state="running", retry_count=2, serialization_retry_count=2)
         with patch("odoo.addons.base_bg.models.bg_job._logger.error"):
-            job._handle_job_error("could not serialize access due to concurrent update")
+            requeued = job._handle_job_error(self._serialization_error())
 
+        self.assertFalse(requeued)
         job.invalidate_recordset()
         self.assertEqual(job.state, "failed")
 
@@ -622,12 +668,48 @@ class TestBgJob(TransactionCase):
         """Non-serialization errors keep the original retry-then-fail behavior, no backoff gate."""
         job = self._create_job(name="Real Error Job", state="running", max_retries=2)
         with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
-            job._handle_job_error("Some real failure")
+            requeued = job._handle_job_error("Some real failure")
 
+        self.assertTrue(requeued)
         job.invalidate_recordset()
         self.assertEqual(job.state, "enqueued")
         self.assertEqual(job.retry_count, 1)
+        self.assertEqual(job.serialization_retry_count, 0)
         self.assertFalse(job.next_retry_at, "Non-transient retries must not set a backoff gate")
+
+    def test_transient_retries_do_not_starve_real_error_budget(self):
+        """A job that burned transient retries still gets its full non-transient budget."""
+        job = self._create_job(name="Mixed", state="running", max_retries=3, retry_count=4, serialization_retry_count=4)
+        with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
+            requeued = job._handle_job_error("A genuine business error")
+
+        self.assertTrue(requeued, "the first real error must retry even after transient retries")
+        job.invalidate_recordset()
+        self.assertEqual(job.state, "enqueued")
+        self.assertEqual(job.retry_count, 5)  # non-transient attempts = 5 - 4 = 1 < max_retries(3)
+
+    def test_malformed_int_params_fall_back_to_default(self):
+        """A non-integer system parameter must not crash the runner; it falls back to the default."""
+        self._set_param("base_bg.max_concurrent_jobs", "not-a-number")
+        self._set_param("base_bg.serialization_max_retries", "")
+        with patch("odoo.addons.base_bg.models.bg_job._logger.warning"):
+            self.assertEqual(self.BgJob._get_max_concurrent_jobs(), 0)
+            self.assertEqual(self.BgJob._get_serialization_max_retries(), 10)
+            # The picker must not raise with a malformed cap param.
+            self.BgJob._get_next_job()
+
+    def test_fail_and_cancel_clear_backoff_gate(self):
+        """fail() and cancel() clear next_retry_at so no stale gate lingers on the row."""
+        future = fields.Datetime.now() + timedelta(minutes=5)
+        job = self._create_job(name="Fail Clears Gate", state="running", next_retry_at=future)
+        job.fail("done for", notify=False)
+        job.invalidate_recordset()
+        self.assertFalse(job.next_retry_at)
+
+        job2 = self._create_job(name="Cancel Clears Gate", state="enqueued", next_retry_at=future)
+        job2.cancel("nope")
+        job2.invalidate_recordset()
+        self.assertFalse(job2.next_retry_at)
 
     def test_get_next_job_skips_jobs_in_backoff(self):
         """Jobs whose backoff window is still in the future are not picked up."""
@@ -640,13 +722,25 @@ class TestBgJob(TransactionCase):
         self.assertEqual(self.BgJob._get_next_job(), eligible)
 
     def test_get_next_job_respects_concurrency_cap(self):
-        """With the cap set and already reached, no new job is picked."""
+        """With the cap set and already reached by a fresh running job, no new job is picked."""
         self.BgJob.search([("state", "in", ["enqueued", "running"])]).write({"state": "canceled"})
-        self.env["ir.config_parameter"].sudo().set_param("base_bg.max_concurrent_jobs", "1")
+        self._set_param("base_bg.max_concurrent_jobs", "1")
+        self._set_cron_timeout(5)
         self._create_job(name="Already Running", state="running", start_time=fields.Datetime.now())
         self._create_job(name="Waiting For Slot", state="enqueued")
 
         self.assertEqual(self.BgJob._get_next_job(), self.env["bg.job"])
+
+    def test_concurrency_cap_ignores_orphaned_running_jobs(self):
+        """A job stuck in 'running' past the cron timeout must not consume the cap."""
+        self.BgJob.search([("state", "in", ["enqueued", "running"])]).write({"state": "canceled"})
+        self._set_param("base_bg.max_concurrent_jobs", "1")
+        self._set_cron_timeout(5)  # limit_time_real_cron = 300s
+        stale = fields.Datetime.now() - timedelta(hours=1)
+        self._create_job(name="Orphan", state="running", start_time=stale)
+        job = self._create_job(name="Fresh", state="enqueued")
+
+        self.assertEqual(self.BgJob._get_next_job(), job)
 
     def test_concurrency_cap_disabled_by_default(self):
         """With the default parameter (0) the cap is off and jobs run normally."""
@@ -665,3 +759,15 @@ class TestBgJob(TransactionCase):
         job.invalidate_recordset()
         self.assertEqual(job.state, "done")
         mock_trigger.assert_not_called()
+
+    def test_finish_enqueues_next_and_marks_it_eligible(self):
+        """finish() enqueues the next batch job, which the runner then sees as eligible."""
+        self.BgJob.search([("state", "=", "enqueued")]).write({"state": "canceled"})
+        job1 = self._create_job(name="Batch head", state="running")
+        job2 = self._create_job(name="Batch tail", state="waiting")
+        job1.next_job_id = job2
+        job1.finish()
+
+        job2.invalidate_recordset()
+        self.assertEqual(job2.state, "enqueued")
+        self.assertTrue(self.BgJob._has_eligible_jobs(), "the freshly-enqueued next job must be pickable")

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -569,7 +569,7 @@ class TestBgJob(TransactionCase):
         self.assertEqual(mock_get.call_count, 1)
         mock_rollback.assert_called_once()
 
-    # --- Serialization backoff, eligibility and concurrency cap -------------
+    # --- Serialization backoff, eligibility and runner memory cleanup -------
 
     def _serialization_error(self):
         """Build a real psycopg2 serialization failure (SQLSTATE 40001)."""
@@ -738,3 +738,37 @@ class TestBgJob(TransactionCase):
         job2.invalidate_recordset()
         self.assertEqual(job2.state, "enqueued")
         self.assertTrue(self.BgJob._has_eligible_jobs(), "the freshly-enqueued next job must be pickable")
+
+    def test_run_releases_orm_cache(self):
+        """run() drops the ORM cache after each job (success and error) to flatten the
+        long-lived runner's memory between jobs."""
+        # Success path
+        partner = self.env["res.partner"].create({"name": "Mem partner"})
+        ok_job = self._create_job(
+            name="Mem OK",
+            state="running",
+            model="res.partner",
+            method="exists",
+            kwargs_json={"_record_ids": [partner.id]},
+        )
+        with patch.object(self.env.cr, "commit"), patch.object(type(ok_job), "_notify_user"), patch.object(
+            type(self.env), "invalidate_all"
+        ) as mock_inv:
+            ok_job.run()
+        mock_inv.assert_called()
+
+        # Error path
+        err_job = self._create_job(
+            name="Mem ERR",
+            state="running",
+            model="bg.job",
+            method="dummy_boom",
+            kwargs_json={"_record_ids": [ok_job.id]},
+        )
+        with patch.object(type(err_job), "dummy_boom", create=True, side_effect=ValueError("boom")), patch.object(
+            self.env.cr, "commit"
+        ), patch.object(self.env.cr, "rollback"), patch(
+            "odoo.addons.base_bg.models.bg_job._logger.warning"
+        ), patch.object(type(self.env), "invalidate_all") as mock_inv_err:
+            err_job.run()
+        mock_inv_err.assert_called()


### PR DESCRIPTION
## What

Hardens the `base_bg` background-job engine against the two problems in ticket
124538: **(A)** the queue not draining due to serialization contention, and
**(B)** the runner's memory accumulating across jobs (contributing to worker
OOM-kills). Complements the existing in-process retry for **acquisition**
serialization in `_cron_run_enqueued_jobs`.

## A — Serialization contention (queue not draining)

Under load, jobs failed with `could not serialize access due to concurrent update`
(SQLSTATE 40001) raised **during execution** — row-level conflicts on shared tables
(notably `discuss_channel_member` updates from message posting, and `ir_cron`
acquisition). They were retried instantly, re-collided, and once `max_retries` was
hit turned healthy jobs into permanent failures; and `finish()` triggered every
cron on each completed job, adding `ir_cron` churn.

- **Backoff for transient run errors.** Serialization / deadlock / lock failures
  are retried with exponential backoff + jitter on a **dedicated** budget
  (`transient_retry_count` vs `base_bg.transient_max_retries`, default 10), kept
  separate from the normal `retry_count` / `max_retries` budget so a contention
  spike never turns healthy jobs into permanent failures. `retry_count` stays the
  total attempt count. Detection reuses Odoo's `PG_CONCURRENCY_EXCEPTIONS_TO_RETRY`
  and walks the `__cause__`/`__context__` chain.
- **Backoff-aware picker.** `_get_next_job` skips jobs inside their `next_retry_at`
  window (UTC bind param, not SQL `NOW()`), and a cron wake-up is scheduled at
  `next_retry_at`. The runner only re-triggers while *eligible* jobs remain.
- **Less cron churn.** `finish()` no longer triggers the cron on every job.
- **Robustness.** `base_bg.*` int params are parsed safely; `fail()`/`cancel()`
  clear the backoff gate. `_handle_job_error` returns whether it re-enqueued.

## B — Runner memory cleanup

The runner loops many jobs inside one long-lived cron process and never released
each job's ORM cache. `run()` now calls `env.invalidate_all()` after the successful
commit and after the rollback in the error path, flattening the runner's memory
curve between jobs.

New fields `next_retry_at`, `transient_retry_count`.

## Out of scope (tracked in the ticket)

Per-record serialization / a concurrency cap (the backoff addresses the contention;
a cap can be reintroduced later if needed), and the AI-job-side / infra work
(bounded searches, per-runner memory limits, websocket thundering herd).

## Consumers

`export_bg` and `account_statement_import_sheet_file_bg` use the unchanged
`bg_enqueue` API and are unaffected. `saas_provider_upgrade` overrides
`_handle_job_error`; it is adapted to the new structure in the linked PR
ingadhoc/odoo-saas-adhoc#3094.

## Test plan

`base_bg` suite green on a clean DB (43/43), covering transient backoff, the
dedicated budget vs mixed real errors, malformed-param fallback, backoff-gate
clearing, eligibility skipping, batch continuation and ORM-cache release on both
run() paths.

Internal ticket: 124538
