### PR TITLE
[FIX] portal_backend: don't fix menu groups on read-only requests

### DIFF
--- a/portal_backend/models/ir_ui_menu.py
+++ b/portal_backend/models/ir_ui_menu.py
@@ -1,18 +1,19 @@
-from odoo import Command, api, models, tools
+from odoo import Command, models
 
 
 class IrUiMenu(models.Model):
     _inherit = "ir.ui.menu"
 
-    @api.model
-    @tools.ormcache("self.env.uid", "debug", "self.env.lang")
-    def load_menus(self, debug):
+    def _register_hook(self):
         """Assert all parent menus has internal group."""
         # NOTE:
-        # It is important to do it here to capture the case when portal_backend is already installed and the user
-        # installs another module with a parent menu without internal group.
+        # It is done on registry load, and not when loading menus, because that runs on read-only
+        # requests. Registry is reloaded after installing modules, so this also captures the case
+        # when portal_backend is already installed and the user installs another module with a
+        # parent menu without internal group.
         parent_menus_wo_group = self.sudo().search([("parent_id", "=", False), ("group_ids", "=", False)])
-        parent_menus_wo_group.with_context(from_config=True).write(
-            {"group_ids": [Command.link(self.env.ref("base.group_user").id)]}
-        )
-        return super().load_menus(debug=debug)
+        if parent_menus_wo_group:
+            parent_menus_wo_group.with_context(from_config=True).write(
+                {"group_ids": [Command.link(self.env.ref("base.group_user").id)]}
+            )
+        return super()._register_hook()


### PR DESCRIPTION
load_menus runs on read-only requests, so writing the internal group there raised 'cannot execute INSERT in a read-only transaction'. The request was retried with a read/write cursor and succeeded, but the error was logged and turned runbot builds red. Do it on registry load instead, which also happens after installing a module with a parent menu without internal group.