### PR TITLE
[FIX] base_company_dependent: skip company check on comodels without company

### DIFF
--- a/base_company_dependent/models/base.py
+++ b/base_company_dependent/models/base.py
@@ -49,6 +49,9 @@ class Base(models.AbstractModel):
         cd_fields = [f for f in self._fields.values() if f.type == "many2one" and f.company_dependent]
         for field in cd_fields:
             comodel = self.env[field.comodel_name]
+            if "company_id" not in comodel and "company_ids" not in comodel:
+                # comodel shared by every company: nothing to cross-check
+                continue
             company_domain = comodel._check_company_domain(company)
             if not company_domain:
                 continue

--- a/base_company_dependent/tests/company_dependent_models.py
+++ b/base_company_dependent/tests/company_dependent_models.py
@@ -31,3 +31,4 @@ class CompanyDependentTester(models.Model):
     name = fields.Char()
     partner_id = fields.Many2one("res.partner", company_dependent=True)
     partner_regular_id = fields.Many2one("res.partner")
+    currency_id = fields.Many2one("res.currency", company_dependent=True)

--- a/base_company_dependent/tests/test_company_cross_check.py
+++ b/base_company_dependent/tests/test_company_cross_check.py
@@ -107,6 +107,14 @@ class TestCompanyCrossCheck(TransactionCase):
         )
         self.assertTrue(result.get("ids"))
 
+    def test_load_comodel_without_company_field(self):
+        """load() skips a company_dependent Many2one to a comodel without company."""
+        result = self._env_a()[self.MODEL].load(
+            ["name", "currency_id/.id"],
+            [["Tester", str(self.env.ref("base.USD").id)]],
+        )
+        self.assertTrue(result.get("ids"))
+
     def test_sibling_branch_domain_behavior_documented(self):
         """Lock the sibling-branch behavior, whatever _check_company_domain does.
 


### PR DESCRIPTION
Importing any record that holds a `company_dependent` Many2one pointing to a comodel **without** a company field crashes the whole import.

`_check_company_dependent_m2o()` (added in #406) builds `comodel._check_company_domain(company)` for every `company_dependent` m2o and searches with it, without checking that the comodel actually has `company_id` / `company_ids`. `res.currency` has neither in 19.0, so:

```
ValueError: Invalid field res.currency.company_id in condition ('company_id', 'in', [1, False])
```

Symptom in the field: `res.partner.property_purchase_currency_id` is `company_dependent` on `res.currency`, so importing contacts — even a two column file with just `id` + tags — fails with an "Odoo Server Error" for every vendor that has a supplier currency set, already on the "Test" dry run. Module CSV data is loaded through `load()` as well (`odoo/tools/convert.py`), so data files are exposed to the same crash.

Fix: skip the check when the comodel has no company field. Those records are shared by every company, there is nothing to cross-check.

### Test plan

- New `test_load_comodel_without_company_field` in `TestCompanyCrossCheck`: `load()` a `company_dependent` m2o to `res.currency` on the transient test model.
- Without the fix: 1 error, exactly the `ValueError` above. With the fix: 44 tests, 0 failed, 0 error(s).

### Note for the reviewer

The existing `if not company_domain: continue` guard never triggers: `_check_company_domain` returns a `Domain`, which is always truthy. Left untouched, out of scope of this fix.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/125180
