### PR TITLE
[FIX] portal_holidays: grant the portal backend group access to employee_overtime on hr.leave

### DIFF
--- a/portal_holidays/models/hr_leave.py
+++ b/portal_holidays/models/hr_leave.py
@@ -1,11 +1,19 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 from odoo.exceptions import AccessError
 
 
 class HolidaysRequest(models.Model):
     _inherit = "hr.leave"
+
+    # Same extension the module already applies to hr.leave.allocation: the
+    # core field (hr_holidays_attendance) is restricted to base.group_user,
+    # but this module exposes the leave form to its portal backend group, so
+    # the view element that depends on employee_overtime would be visible to
+    # a group that cannot read the field (Odoo 19 flags it as an access
+    # rights inconsistency on every view validation).
+    employee_overtime = fields.Float(groups="base.group_user,portal_holidays.group_portal_backend_holiday")
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
## What

`hr_holidays_attendance` defines `employee_overtime` on both `hr.leave` and `hr.leave.allocation`, restricted to `base.group_user`. This module already extends the field groups on `hr.leave.allocation` so its `group_portal_backend_holiday` can read it — but never did the same on `hr.leave`, and the leave form it exposes to that group contains the core element that depends on the field:

```
<div class="oe_inline" invisible="not employee_id or not overtime_deductible or employee_overtime <= 0"/>
```

Since Odoo 19, view validation flags this on every update as an **Access Rights Inconsistency** warning (the element is shown for `base.group_user | portal_holidays.group_portal_backend_holiday` but the field is only accessible to `base.group_user`).

## Fix

Extend the field groups on `hr.leave` exactly like the module already does for the allocation:

```python
employee_overtime = fields.Float(groups="base.group_user,portal_holidays.group_portal_backend_holiday")
```

Kwargs merge with the core definition, so the compute is untouched — only the groups change.

## Test plan

- Upgrade a database with `portal_holidays` installed: the 4 `ir_ui_view` warnings disappear from the update log.
- A user in the portal backend holiday group opens a leave request with deductible overtime: the overtime hint renders instead of being access-blocked.

Found by the migration e2e (runbot) while upgrading a demo-full base — internal task 69634.
