### PR TITLE
[FIX] portal_backend: assert the parent menus group on registry load

### DIFF
--- a/portal_backend/models/ir_ui_menu.py
+++ b/portal_backend/models/ir_ui_menu.py
@@ -1,18 +1,22 @@
-from odoo import Command, api, models, tools
+from odoo import Command, models
 
 
 class IrUiMenu(models.Model):
     _inherit = "ir.ui.menu"
 
-    @api.model
-    @tools.ormcache("self.env.uid", "debug", "self.env.lang")
-    def load_menus(self, debug):
-        """Assert all parent menus has internal group."""
-        # NOTE:
-        # It is important to do it here to capture the case when portal_backend is already installed and the user
-        # installs another module with a parent menu without internal group.
+    def _register_hook(self):
+        """Assert all parent menus have internal group.
+
+        NOTE:
+        It is done on registry load to capture the case when portal_backend is already installed and the user
+        installs another module with a parent menu without internal group.
+        It can not be done while loading the menus: that route is readonly, so writing there breaks its cursor
+        with "cannot execute INSERT in a read-only transaction" (the request is retried with a read/write one,
+        but the failed query is already logged as an error).
+        """
+        super()._register_hook()
         parent_menus_wo_group = self.sudo().search([("parent_id", "=", False), ("group_ids", "=", False)])
-        parent_menus_wo_group.with_context(from_config=True).write(
-            {"group_ids": [Command.link(self.env.ref("base.group_user").id)]}
-        )
-        return super().load_menus(debug=debug)
+        if parent_menus_wo_group:
+            parent_menus_wo_group.with_context(from_config=True).write(
+                {"group_ids": [Command.link(self.env.ref("base.group_user").id)]}
+            )


### PR DESCRIPTION
`portal_backend` granted `base.group_user` to the parent menus without group from inside its `load_menus` override. That method serves `/web/webclient/load_menus`, a route declared `readonly=True`, so the write hits a read-only cursor:

```
ERROR odoo.sql_db: bad query: b'INSERT INTO "ir_ui_menu_group_rel" ("menu_id", "gid") VALUES (...) ON CONFLICT DO NOTHING'
ERROR: cannot execute INSERT in a read-only transaction
WARNING odoo.http: cannot execute INSERT in a read-only transaction, retrying with a read/write cursor
psycopg2.errors.ReadOnlySqlTransaction: cannot execute INSERT in a read-only transaction
```

The request survives (`http._serve_db` retries it with a read/write cursor), but `odoo.sql_db` already logged the failed query as an error, which is enough to turn a build red. On a real database it happens once, because the retry commits the group. On tests it happens on **every tour that loads the webclient**, since each test rolls that write back — so any module adding an `HttpCase` tour gets these errors in its log on a full OBA database that has a parent menu without group.

## What changes

The assignment moves to `_register_hook`, which runs on a read/write cursor and is called every time the registry is loaded — which is exactly what installing or updating a module does. That keeps the case the original note cared about covered (another module installing a parent menu without internal group *after* `portal_backend`), without writing from a web request.

The `ormcache` on the override is dropped along with it: the core `load_menus` is already cached, and the override existed only for the write.

Also skips the write when there is nothing to fix, so the common case is a single search per registry load.

## Test plan

On a 19.0 database with `portal_backend` installed and three active parent menus stripped of their group (Calendar, WhatsApp, Dashboards), running the three `stock_account_ux` tours of ingadhoc/account-financial-tools#984:

| | `read-only transaction` errors | `ERROR` lines | tours passed |
|---|---|---|---|
| before | 9 | 3 (one per tour) | 3 |
| after | 0 | 0 | 3 |

After the run the three menus have `base.group_user` again, written during the registry load.

Branch name matches ingadhoc/account-financial-tools#984 so runbot builds both in a single bundle.
