### PR TITLE
[FIX] base_bg: cancel orphaned jobs instead of failing them

### DIFF
--- a/base_bg/README.rst
+++ b/base_bg/README.rst
@@ -35,7 +35,7 @@ Job States
 * **Running**: Job is currently being executed
 * **Done**: Job completed successfully
 * **Failed**: Job failed after all retry attempts
-* **Canceled**: Job was manually canceled
+* **Canceled**: Job was manually canceled, or every record it pointed to was deleted before it could run (orphan job)
 
 Usage
 =====
@@ -239,6 +239,7 @@ A separate scheduled action monitors running jobs:
 
 * Detects jobs running longer than 5 hours (configurable)
 * Automatically marks them as failed with timeout error
+* Cancels (instead of failing) jobs whose records no longer exist
 * Prevents stuck jobs from blocking the queue
 
 Security and Permissions

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -195,6 +195,9 @@ class BgJob(models.Model):
         if self.state != "running":
             raise UserError(_("Only running jobs can be executed"))
 
+        if self._cancel_if_orphaned():
+            return
+
         self.env.cr.commit()  # pylint: disable=invalid-commit
         try:
             context = dict(self.context_json or {})
@@ -301,6 +304,26 @@ class BgJob(models.Model):
         record_ids = kwargs.get("_record_ids", [])
         records = self.env[self.model].browse(record_ids)
         return records
+
+    def _cancel_if_orphaned(self) -> bool:
+        """
+        Cancel this job (and the rest of its batch) when every record it points to is gone.
+
+        A job can outlive its records (a GC or an FK cascade wins the race). Such a job did
+        not fail — there is nothing left to run it on — so it is canceled instead of failed,
+        keeping failure metrics and notifications meaningful. Jobs that point to no records
+        at all (model-level methods) are not orphans.
+
+        :return: True if the job was canceled as an orphan
+        """
+        self.ensure_one()
+        records = self._get_records()
+        if not records or records.exists():
+            return False
+        _logger.info("Job %s canceled: the records it points to no longer exist", self.name)
+        self.cancel(message=_("The records of this job no longer exist"))
+        self._get_next_jobs().cancel(message=_("Previous job in batch was canceled"))
+        return True
 
     def _handle_job_error(self, error: Exception | str) -> bool:
         """
@@ -564,6 +587,8 @@ class BgJob(models.Model):
                 # Per-job savepoint: a job that raises would otherwise abort the whole reaper
                 # and leave every other timed-out job running forever.
                 with self.env.cr.savepoint():
+                    if job._cancel_if_orphaned():
+                        continue
                     job._handle_job_error(timeout_msg)
                     if job.state == "failed":
                         job._notify_user(_("Job %s timed out") % job._get_html_link(title=job_name))

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -162,6 +162,56 @@ class TestBgJob(TransactionCase):
 
         self.assertEqual(job.state, "running")
 
+    def test_run_cancels_orphaned_job(self):
+        """run() cancels a job whose records were all deleted, along with the rest of its batch."""
+        partner = self.env["res.partner"].create({"name": "Gone"})
+        job = self._create_job(name="Orphan Run Job", state="running", kwargs_json={"_record_ids": [partner.id]})
+        chained = self._create_job(name="Chained After Orphan", batch_key=job.batch_key, state="waiting")
+        job.next_job_id = chained.id
+        partner.unlink()
+
+        with patch.object(type(self.BgJob), "_notify_user") as mock_notify:
+            job.run()
+
+        self.assertEqual(job.state, "canceled", "an orphan job is canceled, not failed")
+        self.assertEqual(chained.state, "canceled")
+        mock_notify.assert_not_called()
+
+    def test_run_with_partially_deleted_records_is_not_orphaned(self):
+        """One surviving record is enough: the job is not an orphan and runs normally."""
+        keep = self.env["res.partner"].create({"name": "Keep"})
+        gone = self.env["res.partner"].create({"name": "Gone"})
+        job = self._create_job(state="running", kwargs_json={"_record_ids": [keep.id, gone.id]})
+        gone.unlink()
+
+        with patch.object(self.env.cr, "commit"), patch.object(type(self.BgJob), "_notify_user"):
+            job.run()
+
+        self.assertEqual(job.state, "done")
+
+    def test_run_with_no_records_is_not_orphaned(self):
+        """A job that points to no records at all (model-level method) runs normally."""
+        job = self._create_job(state="running", kwargs_json={"_record_ids": []})
+
+        with patch.object(self.env.cr, "commit"):
+            job.run()
+
+        self.assertEqual(job.state, "done")
+
+    def test_cron_check_running_jobs_cancels_orphaned_job(self):
+        """The reaper cancels a timed-out job whose records are gone, and still times out the rest."""
+        partner = self.env["res.partner"].create({"name": "Gone"})
+        orphan = self._create_timed_out_job("Orphan Timed Out", kwargs_json={"_record_ids": [partner.id]})
+        healthy = self._create_timed_out_job("Healthy Timed Out")
+        partner.unlink()
+
+        self._set_cron_timeout(300)
+        with patch.object(type(self.BgJob), "_notify_user"), tools.mute_logger("odoo.addons.base_bg.models.bg_job"):
+            self.BgJob._cron_check_running_jobs()
+
+        self.assertEqual(orphan.state, "canceled", "an orphan job is canceled, not failed")
+        self.assertEqual(healthy.state, "failed")
+
     def test_cron_check_running_jobs_recent(self):
         """Test that recent running jobs are not marked as timed out."""
         # Create a job that started recently


### PR DESCRIPTION
### Problema

Un job puede sobrevivir a sus registros: un GC (o un `ON DELETE CASCADE` de PG) los borra mientras el job sigue `enqueued`/`waiting`/`running`. Ese job no falló — no queda nada sobre qué correrlo — pero hoy termina `failed` ("Job timed out" o reintentos agotados) con su batch cancelado como "Previous job in batch failed": ensucia las métricas de fallas y notifica al usuario algo no accionable.

### Cambio

`_cancel_if_orphaned()`: si el job apunta a ids y ya no existe ninguno, se cancela — con "The records of this job no longer exist" y su cadena con "Previous job in batch was canceled" — sin notificar. Se chequea en `run()` (el runner) y en `_cron_check_running_jobs` (el reaper, dentro del savepoint por job). Jobs sin registros (métodos model-level) y jobs con registros sobrevivientes no cambian.

Cubre jobs de cualquier modelo, presente o futuro; los guards `exists()` que cada modelo pueda tener (p. ej. `saas_provider_upgrade`) quedan como red de seguridad.

### Tests

`base_bg/tests/test_bg_job.py`:

- `test_run_cancels_orphaned_job`: run() cancela el job y su cadena, sin notificar.
- `test_run_with_partially_deleted_records_is_not_orphaned` y `test_run_with_no_records_is_not_orphaned`: los no-huérfanos corren normal.
- `test_cron_check_running_jobs_cancels_orphaned_job`: el reaper cancela el huérfano y sigue venciendo el resto.

Tarea: https://www.adhoc.inc/odoo/project.task/72756