### PR TITLE
[FIX] portal_holidays: restrict overtime hint to internal users in view

### DIFF
--- a/portal_holidays/views/portal_holidays_views.xml
+++ b/portal_holidays/views/portal_holidays_views.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <!-- The overtime hint depends on employee_overtime, restricted to
+    base.group_user by hr_holidays_attendance. Granting the field to
+    group_portal_backend_holiday in Python is not enough: during -u all the
+    views of hr_holidays_attendance are validated before this module's
+    override is loaded in the registry, so the element must not be shown to
+    the portal group at the view level (DB) or every full upgrade logs an
+    Access Rights Inconsistency warning. -->
+    <record id="hr_leave_allocation_view_form_inherit_portal_holidays" model="ir.ui.view">
+        <field name="name">hr.leave.allocation.view.form.inherit.portal.holidays</field>
+        <field name="model">hr.leave.allocation</field>
+        <field name="inherit_id" ref="hr_holidays.hr_leave_allocation_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[field[@name='employee_overtime']]" position="attributes">
+                <attribute name="groups">base.group_user</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <!-- Add My Time Off Action for portal holidays users -->
     <record id="hr_leave_action_my_portal_holidays" model="ir.actions.act_window">
         <field name="name">My Time Off</field>


### PR DESCRIPTION
## Problem

Every full upgrade (`-u all`) of a database with `portal_holidays` installed logs 4 `Access Rights Inconsistency` warnings on the `hr.leave.allocation` views:

- `hr_holidays_attendance` adds a div showing `employee_overtime` (restricted to `base.group_user`) to the allocation form.
- This module grants read access on that field to `group_portal_backend_holiday` **in Python** (field `groups` override).
- During `-u all`, the views of `hr_holidays_attendance` (module ~284 of ~750) are validated **before** `portal_holidays` (~381) is loaded into the registry. At that point the validator sees the element shown to the portal group (its `ir.model.access` rows are already in the DB) while the field is still only accessible to `base.group_user` — a Python group grant from a later module can never win that window.

This is why the earlier Python-side fix (ea602fd) silenced CI installs but not full upgrades: 18→19 migration runs reproduce the 4 warnings on every pass (verified on two consecutive upgrade builds).

## Fix

Restrict the overtime hint element to `base.group_user` at the **view level**: view inheritance lives in the DB, so it holds during the whole upgrade, including the window before this module's Python is loaded. Portal backend holiday users no longer see the "Extra Hours Available" hint in their allocations; internal users are unaffected.

## Test plan

- `-u all` (double pass) over a migrated database with `portal_holidays` installed: no `Access Rights Inconsistency` warnings referencing `employee_overtime` (previously 4).
- As an internal user, the "Extra Hours Available" hint still shows on overtime-deductible allocations.
- As a portal backend holiday user, "My Allocations" opens and the form renders without the hint.

Internal task: https://www.adhoc.inc/odoo/project.task/69634