### PR TITLE
[FIX] base_bg: reaper timeout config, duplicate timeout DM, notification escaping

### DIFF
--- a/account_reconcile_bg/models/account_bank_statement_line.py
+++ b/account_reconcile_bg/models/account_bank_statement_line.py
@@ -70,14 +70,16 @@ class AccountBankStatementLine(models.Model):
 
         try:
             self.with_context(account_reconcile_bg_skip=True).set_batch_payment_bank_statement_line(batch_payment_id)
-            return Markup(
-                _("Bank reconciliation completed successfully:<br><a href='%s' target='_blank'>%s</a>")
-                % (st_line_url, st_line_name)
+            # % on the Markup template escapes the interpolations (the line name is user data)
+            return Markup(_("Bank reconciliation completed successfully:<br><a href='%s' target='_blank'>%s</a>")) % (
+                st_line_url,
+                st_line_name,
             )
         except Exception as e:
-            return Markup(
-                _("Bank reconciliation failed:<br><a href='%s' target='_blank'>%s</a><br><br>Error: %s")
-                % (st_line_url, st_line_name, str(e))
+            return Markup(_("Bank reconciliation failed:<br><a href='%s' target='_blank'>%s</a><br><br>Error: %s")) % (
+                st_line_url,
+                st_line_name,
+                str(e),
             )
         finally:
             self.write({"reconciliation_in_background": False})

--- a/account_reconcile_bg/models/bg_job.py
+++ b/account_reconcile_bg/models/bg_job.py
@@ -13,8 +13,8 @@ class BgJob(models.Model):
         self._clear_reconciliation_bg_flag()
         return res
 
-    def fail(self, error_message: str):
-        res = super().fail(error_message)
+    def fail(self, error_message: str, notify: bool = True):
+        res = super().fail(error_message, notify=notify)
         self._clear_reconciliation_bg_flag()
         return res
 

--- a/account_statement_import_sheet_file_bg/models/account_statement_import.py
+++ b/account_statement_import_sheet_file_bg/models/account_statement_import.py
@@ -152,12 +152,11 @@ class AccountStatementImport(models.TransientModel):
                     url = f"{base_url}/odoo/account.bank.statement/{statement_id}"
                     name = statement.name or f"Statement {statement_id}"
 
-                    res_html = (
-                        "The following bank statement has been created:<br>"
-                        f'<a href="{url}" target="_blank">{name}</a><br>'
-                    )
-
-                    return Markup(res_html)
+                    # % on the Markup template escapes the interpolations
+                    # (the statement name is user data)
+                    return Markup(
+                        _('The following bank statement has been created:<br><a href="%s" target="_blank">%s</a><br>')
+                    ) % (url, name)
             except Exception as e:
                 return _("Error importing bank statement: %s") % str(e)
             return result

--- a/base_bg/README.rst
+++ b/base_bg/README.rst
@@ -92,6 +92,11 @@ The ``bg_enqueue()`` method is the primary way to create background jobs:
 
 The method returns a notification action that informs the user the job has been queued.
 
+When the job finishes, the executed method's return value (if any) is sent to the user
+as a direct message. A plain string is escaped before rendering: if your method returns
+HTML, return a ``markupsafe.Markup`` — with any user-provided value already escaped,
+e.g. interpolated through the ``%`` operator of a ``Markup`` template.
+
 Real-world Examples
 ===================
 

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -274,7 +274,9 @@ class BgJob(models.Model):
             }
         )
         if notify:
-            message = _("Job %s failed: %s") % (self.name, error_message)
+            # Link the job itself: the failure DM is the only notification (the reaper
+            # does not re-notify) and the user needs a way to reach the failed job.
+            message = _("Job %s failed: %s") % (self._get_html_link(title=self.name), error_message)
             # exists(): a job can outlive its records, and browsing a dropped id is truthy —
             # _get_html_link() reads display_name on it and would raise MissingError.
             records = self._get_records().exists()
@@ -613,9 +615,9 @@ class BgJob(models.Model):
                         continue
                     if not overdue:
                         continue
+                    # No extra notification here: when the job fails permanently,
+                    # _handle_job_error -> _give_up -> fail() already notifies the user once.
                     job._handle_job_error(timeout_msg)
-                    if job.state == "failed":
-                        job._notify_user(_("Job %s timed out") % job._get_html_link(title=job_name))
             except Exception as error:
                 # No invalidation needed: the savepoint rollback already cleared the cache
                 # and the pending updates (_FlushingSavepoint.rollback -> cr.clear()).

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -570,24 +570,48 @@ class BgJob(models.Model):
             self.env["base.bg"].sudo()._trigger_crons()
 
     @api.model
+    def _get_reaper_timeout(self) -> int:
+        """
+        Effective real-time limit (seconds) for cron-run jobs, mirroring how the
+        server resolves ``limit_time_real_cron`` in each mode:
+
+        - prefork (``workers`` > 0): ``0``/unset means no limit, ``-1`` delegates
+          to ``--limit-time-real`` (``PreforkServer.__init__``).
+        - threaded (``workers`` == 0): the value only applies when > 0, anything
+          else falls back to ``--limit-time-real`` (``ThreadedServer.process_limit``).
+
+        :return: the limit, or 0 when there is none.
+        """
+        timeout = tools.config.get("limit_time_real_cron") or 0
+        if timeout > 0:
+            return timeout
+        if timeout == -1 or not tools.config.get("workers"):
+            return tools.config.get("limit_time_real") or 0
+        return 0
+
+    @api.model
     def _cron_check_running_jobs(self):
-        """Check running background jobs honoring the cron timeout (seconds)."""
-        timeout_seconds = tools.config.get("limit_time_real_cron") or 0
-        cutoff_date = fields.Datetime.now() - timedelta(seconds=timeout_seconds)
-        jobs = self.search(
-            [
-                ("start_time", "<", cutoff_date),
-                ("state", "=", "running"),
-            ]
-        )
+        """
+        Time out running jobs past the cron real-time limit, and cancel orphaned ones.
+
+        The orphan sweep is independent of the time limit: a running job whose
+        records are gone can never finish on its own, so it is swept even when no
+        limit is configured and nothing can ever time out.
+        """
+        timeout_seconds = self._get_reaper_timeout()
+        cutoff_date = fields.Datetime.now() - timedelta(seconds=timeout_seconds) if timeout_seconds > 0 else None
+        jobs = self.search([("state", "=", "running")])
         timeout_msg = _("Job timed out")
         for job in jobs:
             job_name = job.name
+            overdue = bool(cutoff_date and job.start_time and job.start_time < cutoff_date)
             try:
                 # Per-job savepoint: a job that raises would otherwise abort the whole reaper
                 # and leave every other timed-out job running forever.
                 with self.env.cr.savepoint():
                     if job._cancel_if_orphaned():
+                        continue
+                    if not overdue:
                         continue
                     job._handle_job_error(timeout_msg)
                     if job.state == "failed":
@@ -597,6 +621,11 @@ class BgJob(models.Model):
                 # and the pending updates (_FlushingSavepoint.rollback -> cr.clear()).
                 if self._is_transient_error(error):
                     _logger.warning("Job %s not timed out yet, transient error: %s", job_name, error)
+                    continue
+                if not overdue:
+                    # The bare-fail recovery below is for jobs already past their limit;
+                    # a job that merely failed its orphan check keeps running.
+                    _logger.exception("Could not check job %s, leaving it for the next run", job_name)
                     continue
                 _logger.exception("Could not time out job %s, giving up on it", job_name)
                 try:

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -20,6 +20,13 @@ _logger = logging.getLogger(__name__)
 # (trigger storm). Mirrors saas_provider.saas_database._acquire_next_task.
 MAX_ACQUIRE_RETRIES = 5
 
+# Fallback grace period (seconds) for the orphan sweep when no real-time limit is
+# configured at all. A job whose records vanished a moment ago may still be running
+# in another worker: cancelling it in flight lets its own finish() clobber the cancel
+# and resurrect the batch. With a limit configured the sweep uses that instead — past
+# it the worker would have been killed anyway, so the job is genuinely presumed dead.
+ORPHAN_SWEEP_GRACE = 3600
+
 
 class BgJob(models.Model):
     _name = "bg.job"
@@ -601,20 +608,26 @@ class BgJob(models.Model):
 
         The orphan sweep is independent of the time limit: a running job whose
         records are gone can never finish on its own, so it is swept even when no
-        limit is configured and nothing can ever time out.
+        limit is configured and nothing can ever time out. It keeps a floor of its
+        own (the limit, or ORPHAN_SWEEP_GRACE when there is none) so that a job that
+        just started is never cancelled while another worker is still running it.
         """
+        now = fields.Datetime.now()
         timeout_seconds = self._get_reaper_timeout()
-        cutoff_date = fields.Datetime.now() - timedelta(seconds=timeout_seconds) if timeout_seconds > 0 else None
+        cutoff_date = now - timedelta(seconds=timeout_seconds) if timeout_seconds > 0 else None
+        orphan_cutoff = cutoff_date or now - timedelta(seconds=ORPHAN_SWEEP_GRACE)
         jobs = self.search([("state", "=", "running")])
         timeout_msg = _("Job timed out")
         for job in jobs:
             job_name = job.name
             overdue = bool(cutoff_date and job.start_time and job.start_time < cutoff_date)
+            # A running job with no start_time cannot be dated: it is stuck by definition.
+            sweepable = not job.start_time or job.start_time < orphan_cutoff
             try:
                 # Per-job savepoint: a job that raises would otherwise abort the whole reaper
                 # and leave every other timed-out job running forever.
                 with self.env.cr.savepoint():
-                    if job._cancel_if_orphaned():
+                    if sweepable and job._cancel_if_orphaned():
                         continue
                     if not overdue:
                         continue

--- a/base_bg/models/bg_job.py
+++ b/base_bg/models/bg_job.py
@@ -7,7 +7,7 @@ import random
 from datetime import timedelta
 
 import psycopg2
-from markupsafe import Markup
+from markupsafe import Markup, escape
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.service.model import PG_CONCURRENCY_EXCEPTIONS_TO_RETRY
@@ -276,13 +276,15 @@ class BgJob(models.Model):
         if notify:
             # Link the job itself: the failure DM is the only notification (the reaper
             # does not re-notify) and the user needs a way to reach the failed job.
-            message = _("Job %s failed: %s") % (self._get_html_link(title=self.name), error_message)
+            # escape() promotes the template to Markup, escaping the interpolations:
+            # error_message (often a traceback repr with angle brackets) is not HTML.
+            message = escape(_("Job %s failed: %s")) % (self._get_html_link(title=self.name), error_message)
             # exists(): a job can outlive its records, and browsing a dropped id is truthy —
             # _get_html_link() reads display_name on it and would raise MissingError.
             records = self._get_records().exists()
             if records:
                 links = [record._get_html_link() for record in records]
-                message += "<br/>" + _("Related records: %s") % (", ".join(links))
+                message += Markup("<br/>") + escape(_("Related records: %s")) % Markup(", ").join(links)
             self._notify_user(message)
 
     def cancel(self, message: str | None = None):
@@ -453,7 +455,8 @@ class BgJob(models.Model):
         """
         Notify user about job status
 
-        :param result: The result of the job execution
+        :param result: message to post. A plain string is escaped; pass a ``Markup``
+            (with any user-provided value already escaped) to render HTML.
         """
         channel = (
             self.env["discuss.channel"]
@@ -463,7 +466,7 @@ class BgJob(models.Model):
         )
         partner_root_id = self.env.ref("base.partner_root").id
         channel.message_post(
-            body=Markup(result),
+            body=escape(result),
             author_id=partner_root_id,
             message_type="comment",
             subtype_xmlid="mail.mt_comment",

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -130,6 +130,23 @@ class TestBgJob(TransactionCase):
         old_time = fields.Datetime.now() - timedelta(hours=6)
         return self._create_job(name=name, state="running", start_time=old_time, max_retries=1, **vals)
 
+    def test_cron_check_running_jobs_notifies_once_on_permanent_timeout(self):
+        """A permanently timed-out job must DM its creator once, not twice."""
+        job = self._create_timed_out_job("Timed Out Once")
+
+        self._set_cron_timeout(300)
+        with patch.object(type(self.BgJob), "_notify_user") as mock_notify, tools.mute_logger(
+            "odoo.addons.base_bg.models.bg_job"
+        ):
+            self.BgJob._cron_check_running_jobs()
+
+        self.assertEqual(job.state, "failed")
+        mock_notify.assert_called_once()
+        # the single message keeps a clickable reference to the job
+        message = mock_notify.call_args[0][0]
+        self.assertIn("Timed Out Once", message)
+        self.assertIn("data-oe-id", message)
+
     def test_cron_check_running_jobs_skips_poisoned_job(self):
         """A job that raises while being timed out must not abort the reaper for the rest."""
         poisoned = self._create_timed_out_job("Poisoned Job")

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import psycopg2
+from markupsafe import Markup
 from odoo import fields, tools
 from odoo.addons.base_bg.models.base_bg import BaseBg
 from odoo.addons.base_bg.models.bg_job import MAX_ACQUIRE_RETRIES
@@ -124,6 +125,39 @@ class TestBgJob(TransactionCase):
 
         self.assertEqual(job.state, "failed")
         self.assertEqual(job.error_message, "boom")
+
+    def test_fail_notification_escapes_user_data(self):
+        """HTML in the job name or error message must reach the DM inert, not injected."""
+        job = self._create_job(name="<img src=x onerror=alert(1)>", state="running")
+
+        with patch.object(type(self.BgJob), "_notify_user") as mock_notify:
+            job.fail("boom <MissingRecord res.partner>")
+
+        message = mock_notify.call_args[0][0]
+        self.assertIsInstance(message, Markup)
+        self.assertNotIn("<img", str(message))
+        self.assertIn("&lt;MissingRecord res.partner&gt;", str(message))
+        # the job link itself stays clickable
+        self.assertIn("data-oe-id", str(message))
+
+    def test_notify_user_escapes_plain_strings(self):
+        """A plain-string result is escaped; a Markup result keeps its HTML."""
+        job = self._create_job()
+        channel = (
+            self.env["discuss.channel"]
+            .with_user(job.create_uid)
+            .sudo()
+            ._get_or_create_chat([job.create_uid.partner_id.id])
+        )
+
+        job._notify_user("plain <b>bold</b>")
+        plain_body = str(channel.message_ids[0].body)
+        self.assertNotIn("<b>", plain_body)
+        self.assertIn("&lt;b&gt;", plain_body)
+
+        job._notify_user(Markup("<b>bold</b>"))
+        markup_body = str(channel.message_ids[0].body)
+        self.assertIn("<b>bold</b>", markup_body)
 
     def _create_timed_out_job(self, name, **vals):
         """Build a running job whose start_time is already past any cron timeout."""

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -21,10 +21,14 @@ class TestBgJob(TransactionCase):
         self.BgJob = self.env["bg.job"]
         self.base_bg_model = self.env["base.bg"]
         self._limit_time_real_cron = tools.config.get("limit_time_real_cron", 120)
+        self._limit_time_real = tools.config.get("limit_time_real")
+        self._workers = tools.config.get("workers")
 
     def tearDown(self):
-        """Restore original cron timeout and teardown TransactionCase."""
+        """Restore original time limits / server mode and teardown TransactionCase."""
         tools.config["limit_time_real_cron"] = self._limit_time_real_cron
+        tools.config["limit_time_real"] = self._limit_time_real
+        tools.config["workers"] = self._workers
         super().tearDown()
 
     def _set_cron_timeout(self, minutes: int):
@@ -225,6 +229,60 @@ class TestBgJob(TransactionCase):
         # Refresh the job from database
         job = self.BgJob.browse(job.id)
         self.assertEqual(job.state, "running")  # Should still be running
+
+    def test_cron_check_running_jobs_default_config_falls_back_to_limit_time_real(self):
+        """-1 (the core default) must inherit --limit-time-real, not reap every running job."""
+        recent = self._create_job(
+            name="Recent Under Fallback",
+            state="running",
+            start_time=fields.Datetime.now() - timedelta(minutes=30),
+        )
+        stale = self._create_timed_out_job("Stale Under Fallback")
+        tools.config["limit_time_real_cron"] = -1
+        tools.config["limit_time_real"] = 3600
+        with patch.object(type(self.BgJob), "_notify_user"), tools.mute_logger("odoo.addons.base_bg.models.bg_job"):
+            self.BgJob._cron_check_running_jobs()
+        self.assertEqual(recent.state, "running")
+        self.assertEqual(stale.state, "failed")
+
+    def test_cron_check_running_jobs_without_time_limit_reaps_nothing(self):
+        """In prefork, 0 disables the cron time limit: the reaper must leave running jobs alone."""
+        stale = self._create_timed_out_job("Stale Without Limit")
+        tools.config["workers"] = 4
+        tools.config["limit_time_real_cron"] = 0
+        self.BgJob._cron_check_running_jobs()
+        self.assertEqual(stale.state, "running")
+
+        # -1 falling back to a limit_time_real of 0 disables it just the same
+        tools.config["limit_time_real_cron"] = -1
+        tools.config["limit_time_real"] = 0
+        self.BgJob._cron_check_running_jobs()
+        self.assertEqual(stale.state, "running")
+
+    def test_cron_check_running_jobs_threaded_zero_falls_back_to_limit_time_real(self):
+        """In threaded mode 0 is not "no limit": the core falls back to --limit-time-real."""
+        stale = self._create_timed_out_job("Stale Threaded Zero")
+        tools.config["workers"] = 0
+        tools.config["limit_time_real_cron"] = 0
+        tools.config["limit_time_real"] = 3600
+        with patch.object(type(self.BgJob), "_notify_user"), tools.mute_logger("odoo.addons.base_bg.models.bg_job"):
+            self.BgJob._cron_check_running_jobs()
+        self.assertEqual(stale.state, "failed")
+
+    def test_cron_check_running_jobs_without_time_limit_still_cancels_orphans(self):
+        """No time limit must not turn off the orphan sweep: stuck orphans block their batch."""
+        partner = self.env["res.partner"].create({"name": "Gone"})
+        orphan = self._create_timed_out_job("Orphan Without Limit", kwargs_json={"_record_ids": [partner.id]})
+        chained = self._create_job(name="Chained After Orphan", batch_key=orphan.batch_key, state="waiting")
+        orphan.next_job_id = chained.id
+        partner.unlink()
+        tools.config["workers"] = 4
+        tools.config["limit_time_real_cron"] = 0
+
+        self.BgJob._cron_check_running_jobs()
+
+        self.assertEqual(orphan.state, "canceled", "an orphan job is canceled even with no time limit")
+        self.assertEqual(chained.state, "canceled")
 
     def test_jobs_are_sorted_by_priority(self):
         """Jobs with lower priority value should be returned first."""

--- a/base_bg/tests/test_bg_job.py
+++ b/base_bg/tests/test_bg_job.py
@@ -10,7 +10,7 @@ import psycopg2
 from markupsafe import Markup
 from odoo import fields, tools
 from odoo.addons.base_bg.models.base_bg import BaseBg
-from odoo.addons.base_bg.models.bg_job import MAX_ACQUIRE_RETRIES
+from odoo.addons.base_bg.models.bg_job import MAX_ACQUIRE_RETRIES, ORPHAN_SWEEP_GRACE
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
@@ -333,6 +333,38 @@ class TestBgJob(TransactionCase):
         self.BgJob._cron_check_running_jobs()
 
         self.assertEqual(orphan.state, "canceled", "an orphan job is canceled even with no time limit")
+        self.assertEqual(chained.state, "canceled")
+
+    def test_cron_check_running_jobs_spares_freshly_started_orphan(self):
+        """A job whose records just vanished may still be running: the sweep waits for its floor."""
+        partner = self.env["res.partner"].create({"name": "Gone Mid Run"})
+        job = self._create_job(
+            name="Orphan In Flight",
+            state="running",
+            start_time=fields.Datetime.now(),
+            kwargs_json={"_record_ids": [partner.id]},
+        )
+        chained = self._create_job(name="Chained After In Flight", batch_key=job.batch_key, state="waiting")
+        job.next_job_id = chained.id
+        partner.unlink()
+
+        # with a limit configured the sweep uses it as its floor
+        self._set_cron_timeout(60)
+        self.BgJob._cron_check_running_jobs()
+        self.assertEqual(job.state, "running", "an orphan still within the limit is not canceled in flight")
+        self.assertEqual(chained.state, "waiting")
+
+        # and with no limit at all it falls back to ORPHAN_SWEEP_GRACE
+        tools.config["workers"] = 4
+        tools.config["limit_time_real_cron"] = 0
+        self.BgJob._cron_check_running_jobs()
+        self.assertEqual(job.state, "running")
+        self.assertEqual(chained.state, "waiting")
+
+        # past the grace it is swept as before
+        job.start_time = fields.Datetime.now() - timedelta(seconds=ORPHAN_SWEEP_GRACE + 1)
+        self.BgJob._cron_check_running_jobs()
+        self.assertEqual(job.state, "canceled")
         self.assertEqual(chained.state, "canceled")
 
     def test_jobs_are_sorted_by_priority(self):


### PR DESCRIPTION
Three pre-existing fixes in `base_bg/models/bg_job.py`, found while reviewing #437 (they predate that PR). One commit per fix, plus two follow-up commits from the review round:

**1. The reaper failed every running job when `limit_time_real_cron` is unset or 0.**
The cutoff was computed as `tools.config.get("limit_time_real_cron") or 0`. With the core default (`-1`, meaning "use `--limit-time-real`") the cutoff lands one second in the future, and with `0` it lands at *now*: in both cases each reaper run marked every running job as failed and canceled the rest of its batch. The limit is now resolved the way the running server does — prefork: `0`/unset means no limit, `-1` delegates to `--limit-time-real` (`PreforkServer.__init__`); threaded: the value only applies when > 0, anything else falls back to `--limit-time-real` (`ThreadedServer.process_limit`). And when no limit applies, the orphan sweep keeps running instead of skipping the reaper entirely: a stuck running job whose records are gone can never finish on its own and would block its batch forever.

**2. A permanently timed-out job DM'd its creator twice.**
`_handle_job_error -> _give_up -> fail()` already posts "Job X failed: Job timed out", and the reaper loop posted a second "Job X timed out" right after. The loop's re-notification is gone; to keep the clickable job reference it provided, `fail()` now renders the job name as its html link (which also brings that link to every failure DM).

**3. `name` / `error_message` reached the DM unescaped.**
`fail()` interpolated them with plain `%` and `_notify_user` wrapped the result in `Markup()`: an error message with angle brackets (any traceback with an object repr) broke the render, and a crafted job name was stored HTML injected into the creator's DM. The failure message is now built as `Markup` with escaped interpolations, and `_notify_user` escapes its input — a plain-string result renders inert, while methods that mean HTML keep working by returning a `Markup` with its own interpolations escaped. The contract is documented in the README, and the two bg-enqueued methods in this repo that built HTML with plain `%` are aligned to it in their own commits (`account_reconcile_bg`, which also picks up the new `fail(notify=)` signature, and `account_statement_import_sheet_file_bg`).

**Merge together with** ingadhoc/odoo-saas-adhoc#3182 (same branch name, bundled build): `ai_app_adhoc` returns a plain str with HTML from a bg-enqueued method and needs the `Markup` treatment before this lands.

**Test plan:** `--test-tags /base_bg,/account_reconcile_bg` on a 19.0 database: 59 + 4 tests, 0 failed (new since the review: reaper threaded-mode fallback at `0`, orphan sweep with no time limit).

Task: https://www.adhoc.inc/odoo/project.task/72869
