### PR TITLE
[ADD] TESTING_73319.md: marker file to test upgrade old databases — DO NOT MERGE

### DIFF
--- a/TESTING_73319.md
+++ b/TESTING_73319.md
@@ -1,0 +1,6 @@
+# Marcador de prueba — task 73319
+
+Archivo sin efecto funcional. Sirve para verificar que los PRs cargados en un
+ticket de actualización llegan a la base old del upgrade.
+
+No mergear.


### PR DESCRIPTION
**No mergear.** Este PR existe como fixture de prueba y se cierra cuando termine la verificación.

Agrega un `TESTING_73319.md` en la raíz del repo, sin ningún efecto funcional: no toca módulos, no agrega dependencias y no cambia comportamiento.

## Para qué

Verificar de punta a punta que los PRs cargados en un ticket de actualización llegan a la base `old` del upgrade, no solo a la `new`. La presencia o ausencia del archivo en la base es la señal: es inequívoca y no requiere actualizar ningún módulo.

Cambio bajo prueba: ingadhoc/odoo-saas-adhoc#3181.