### PR TITLE
[FIX] base_ux, mail_ux: stop the PDF render from calling the instance back over HTTP

### DIFF
--- a/base_ux/README.rst
+++ b/base_ux/README.rst
@@ -21,6 +21,7 @@ Several Improvements:
     * Make parent field on res.company invisible as it is useless now
     * Keep the activity's description when changing the activity type, regardless of the activity type's description, and change the activity user only if the activity type has a default user.
     * Make company_registry field on res.company invisible as it is useless now
+    * Make the PDF reports self-contained so wkhtmltopdf does not need to call the instance back over HTTP while rendering: the report asset bundles are inlined as a ``<style>`` tag, the ``@font-face`` rules pointing at the instance are dropped (wkhtmltopdf resolves those families from the system fonts of the image that runs it) and the ``/report/barcode/`` images are embedded as data URIs. Each one of those sub-requests needed a free HTTP worker while the worker doing the render was blocked, so on instances with few workers concurrent renders could deadlock each other until limit_time_real. It can be turned off with the system parameter base_ux.report_self_contained (default to 1).
     * On the "Schedule Activity" dialog, show only the first N activity types (ordered by sequence) as quick badges, plus a dropdown to search among all the remaining ones. It applies both when scheduling a new activity and when editing an existing one; on an existing activity its current type is always kept among the badges. N is set through the system parameter base_ux.activity_quick_badges (default to 5).
 
 

--- a/base_ux/models/__init__.py
+++ b/base_ux/models/__init__.py
@@ -12,3 +12,4 @@ from . import ir_actions_server
 from . import mail_activity
 from . import mail_activity_type
 from . import mail_activity_schedule
+from . import ir_actions_report

--- a/base_ux/models/ir_actions_report.py
+++ b/base_ux/models/ir_actions_report.py
@@ -1,0 +1,182 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+import base64
+import logging
+import re
+from html import unescape
+from urllib.parse import parse_qsl, unquote, urlsplit
+
+from markupsafe import Markup
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+# <link type="text/css" rel="stylesheet" href="/web/assets/<unique>/<filename>.css"/>
+ASSET_LINK_RE = re.compile(
+    r"""<link\b[^>]*?\bhref=(?P<q>["'])"""
+    r"""(?P<url>/web/assets/(?P<unique>[^/"']+)/(?P<filename>[^"']+?\.css))"""
+    r"""(?P=q)[^>]*?>""",
+    re.IGNORECASE,
+)
+# <img src="/report/barcode/QR/valor?width=87"/> o
+# <img src="/report/barcode/?barcode_type=QR&amp;value=valor&amp;width=87"/>
+BARCODE_SRC_RE = re.compile(
+    r"""src=(?P<q>["'])(?P<url>/report/barcode/[^"']*)(?P=q)""",
+    re.IGNORECASE,
+)
+BARCODE_PREFIX = "/report/barcode/"
+FONT_FACE_RE = re.compile(r"@font-face\s*\{[^}]*\}", re.IGNORECASE)
+CSS_URL_RE = re.compile(r"""url\(\s*["']?(?P<url>[^)"']+)""", re.IGNORECASE)
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def _prepare_html(self, html, report_model=False):
+        """Heredado para que el html que recibe wkhtmltopdf no dependa de pedidos HTTP
+        contra la propia instancia.
+
+        wkhtmltopdf resuelve contra ``base_url`` (o sea, contra el mismo Odoo) los
+        ``<link>`` de los assets del reporte y los ``<img>`` de los códigos de barras.
+        Eso vuelve el render circular: el worker que atiende el pedido queda bloqueado
+        esperando a wkhtmltopdf, y wkhtmltopdf necesita otro worker libre que le
+        conteste. Con ``workers = 3``, tres renders concurrentes agotan los tres, nadie
+        hace accept() y todo queda trabado hasta ``limit_time_real``; el liveness probe
+        mata el container antes de que el watchdog libere los workers.
+
+        Embebiendo los assets y los códigos de barras, un render no necesita más que su
+        propio worker.
+        """
+        res = super()._prepare_html(html, report_model=report_model)
+        # el core devuelve {} cuando no encuentra el layout
+        if not isinstance(res, tuple) or not self._is_report_self_contained():
+            return res
+        bodies, res_ids, header, footer, specific_paperformat_args = res
+        return (
+            [self._inline_report_resources(body) for body in bodies],
+            res_ids,
+            self._inline_report_resources(header),
+            self._inline_report_resources(footer),
+            specific_paperformat_args,
+        )
+
+    def _is_report_self_contained(self):
+        """Permite desactivar el embebido por parámetro de sistema."""
+        param = self.env["ir.config_parameter"].sudo().get_param("base_ux.report_self_contained", "1")
+        return param not in ("0", "False", "false", "")
+
+    def _inline_report_resources(self, html):
+        if not html:
+            return html
+        content = self._inline_report_asset_links(str(html))
+        content = self._inline_report_barcodes(content)
+        return Markup(content) if isinstance(html, Markup) else content
+
+    # ------------------------------------------------------------
+    # ASSETS
+    # ------------------------------------------------------------
+
+    def _inline_report_asset_links(self, content):
+        def replace(match):
+            css = self._get_report_asset_css(match.group("unique"), match.group("filename"))
+            # "</style" dentro del css cortaría el tag; ante la duda dejamos el link
+            if not css or "</style" in css.lower():
+                return match.group(0)
+            return '<style type="text/css">%s</style>' % self._strip_local_font_faces(css)
+
+        return ASSET_LINK_RE.sub(replace, content)
+
+    def _strip_local_font_faces(self, css):
+        """Saca las reglas ``@font-face`` que apuntan a archivos de la propia instancia.
+
+        Son exactamente las que volverían a meter un pedido HTTP contra nosotros mismos,
+        que es lo que este embebido viene a sacar. Y no se pierde nada: medido sobre los
+        logs de producción, wkhtmltopdf hoy no pide ni una de esas fuentes (solo los dos
+        CSS), porque las resuelve del sistema de la imagen que lo corre. Las ``@font-face``
+        que apuntan afuera (el CDN de Noto) quedan como estaban.
+        """
+        keep = []
+        last = 0
+        for match in FONT_FACE_RE.finditer(css):
+            urls = CSS_URL_RE.findall(match.group(0))
+            has_local = any(not url.startswith(("data:", "http://", "https://", "//")) for url in urls)
+            if has_local:
+                keep.append(css[last : match.start()])
+                last = match.end()
+        keep.append(css[last:])
+        return "".join(keep)
+
+    def _get_report_asset_css(self, unique, filename):
+        """Contenido del bundle de assets al que apunta la url, o None si no se pudo
+        resolver (en ese caso se deja el ``<link>`` como estaba)."""
+        url = self.env["ir.asset"]._get_asset_bundle_url(filename, unique, {})
+        attachment = (
+            self.env["ir.attachment"]
+            .sudo()
+            .search(
+                [
+                    ("public", "=", True),
+                    ("url", "=", url),
+                    ("res_model", "=", "ir.ui.view"),
+                    ("res_id", "=", 0),
+                ],
+                limit=1,
+            )
+        )
+        if not attachment:
+            attachment = self._generate_report_asset_attachment(filename)
+        if not attachment or not attachment.raw:
+            return None
+        return attachment.raw.decode()
+
+    def _generate_report_asset_attachment(self, filename):
+        """Genera el bundle si todavía no existe. No es lo habitual (el webclient lo
+        deja generado), y puede fallar si el cursor es de solo lectura."""
+        try:
+            bundle_name, rtl, asset_type, autoprefix = self.env["ir.asset"]._parse_bundle_name(filename, False)
+            if asset_type != "css":
+                return None
+            bundle = self.env["ir.qweb"]._get_asset_bundle(
+                bundle_name, css=True, js=False, rtl=rtl, autoprefix=autoprefix
+            )
+            if not bundle.stylesheets:
+                return None
+            return bundle.css()
+        except Exception:
+            _logger.warning("No se pudo generar el bundle %s para embeberlo en el reporte", filename, exc_info=True)
+            return None
+
+    # ------------------------------------------------------------
+    # CODIGOS DE BARRAS
+    # ------------------------------------------------------------
+
+    def _inline_report_barcodes(self, content):
+        def replace(match):
+            data_uri = self._get_report_barcode_data_uri(match.group("url"))
+            if not data_uri:
+                return match.group(0)
+            quote = match.group("q")
+            return "src=%s%s%s" % (quote, data_uri, quote)
+
+        return BARCODE_SRC_RE.sub(replace, content)
+
+    def _get_report_barcode_data_uri(self, url):
+        """Misma resolución que el controller ``/report/barcode``, pero en proceso."""
+        try:
+            parts = urlsplit(unescape(url))
+            kwargs = dict(parse_qsl(parts.query))
+            barcode_type = kwargs.pop("barcode_type", None)
+            value = kwargs.pop("value", None)
+            path = parts.path[len(BARCODE_PREFIX) :]
+            if path:
+                barcode_type, _sep, value = path.partition("/")
+                value = unquote(value)
+            if not barcode_type or not value:
+                return None
+            barcode = self.env["ir.actions.report"].barcode(barcode_type, value, **kwargs)
+        except Exception:
+            _logger.warning("No se pudo generar el código de barras %s para embeberlo en el reporte", url)
+            return None
+        return "data:image/png;base64,%s" % base64.b64encode(barcode).decode()

--- a/mail_ux/README.rst
+++ b/mail_ux/README.rst
@@ -15,6 +15,7 @@ Mail UX
 =======
 
  * Always send email with delay
+ * Do not render the report of a mail template more than once while the mail composer is open. ``attachment_ids`` is a stored compute, so the web client recomputes it on every round trip and each recompute used to render the same PDF again (2 to 6 times per composer opening, leaving the orphan attachments behind). The already generated attachment is reused while the report, the record and the record's write_date are the same. The reuse window in seconds is set through the system parameter mail_ux.report_attachment_cache_ttl (default to 600; 0 disables the reuse).
 
 
 Installation

--- a/mail_ux/models/mail_compose_message.py
+++ b/mail_ux/models/mail_compose_message.py
@@ -1,10 +1,112 @@
 from datetime import datetime, timedelta
 
-from odoo import models
+from odoo import fields, models
+
+REPORT_CACHE_PREFIX = "mail_ux.report_cache:"
 
 
 class MailComposeMessage(models.TransientModel):
     _inherit = "mail.compose.message"
+
+    def _compute_attachment_ids(self):
+        """Heredado para no volver a renderizar el reporte en cada onchange.
+
+        ``attachment_ids`` es un compute ``store=True, readonly=False``, así que el
+        webclient lo recalcula en cada round-trip mientras se abre el compositor, y cada
+        recálculo vuelve a llamar a ``_render_qweb_pdf``. Medido en producción: el mismo
+        PDF generado de 2 a 6 veces por apertura del wizard, con los attachments
+        huérfanos correspondientes tirados en la base.
+
+        Reusamos el attachment ya generado mientras siga siendo del mismo reporte, del
+        mismo registro y de una versión del registro no menos vieja que el PDF.
+        """
+        cacheable = self.browse()
+        keys = {}
+        for composer in self:
+            key = composer._get_report_attachment_cache_key()
+            if key:
+                keys[composer.id] = key
+                cacheable |= composer
+
+        super(MailComposeMessage, self - cacheable)._compute_attachment_ids()
+
+        for composer in cacheable:
+            key = keys[composer.id]
+            attachment = composer._find_cached_report_attachment(key)
+            if attachment:
+                composer.attachment_ids = composer.template_id.attachment_ids | attachment
+                continue
+            super(MailComposeMessage, composer)._compute_attachment_ids()
+            composer._label_cached_report_attachment(key)
+
+    def _get_report_attachment_cache_key(self):
+        """Clave de reuso del PDF del reporte, o False si no corresponde cachear.
+
+        Solo cacheamos el caso que dispara el problema y que además es inequívoco: modo
+        comment monorecord, con un único reporte qweb en el template. Con más de un
+        reporte no podemos asociar cada attachment creado con su reporte sin ambigüedad,
+        así que dejamos que resuelva el core.
+        """
+        self.ensure_one()
+        if not self._get_report_attachment_cache_ttl():
+            return False
+        template = self.template_id
+        if not template or self.composition_mode != "comment" or self.composition_batch:
+            return False
+        if len(template.report_template_ids) != 1:
+            return False
+        report = template.report_template_ids
+        if report.report_type not in ("qweb-html", "qweb-pdf"):
+            return False
+        res_ids = self._evaluate_res_ids() or []
+        if len(res_ids) != 1 or not res_ids[0]:
+            return False
+        record = self.env[template.model].browse(res_ids[0]).exists()
+        if not record:
+            return False
+        return "%s%s:%s:%s:%s:%s" % (
+            REPORT_CACHE_PREFIX,
+            report.id,
+            template.model,
+            record.id,
+            fields.Datetime.to_string(record.write_date),
+            self.env.context.get("lang") or self.env.user.lang or "",
+        )
+
+    def _get_report_attachment_cache_ttl(self):
+        """Segundos durante los que se reusa un PDF ya generado. En 0 queda desactivado.
+
+        Acota la ventana en la que un cambio que el reporte muestra pero que no toca la
+        ``write_date`` del propio registro (datos del partner, de la compañía, una
+        traducción) podría verse viejo.
+        """
+        return int(self.env["ir.config_parameter"].sudo().get_param("mail_ux.report_attachment_cache_ttl", 600))
+
+    def _find_cached_report_attachment(self, key):
+        limit_date = fields.Datetime.now() - timedelta(seconds=self._get_report_attachment_cache_ttl())
+        return self.env["ir.attachment"].search(
+            [
+                ("res_model", "=", "mail.compose.message"),
+                ("res_id", "=", 0),
+                ("create_uid", "=", self.env.uid),
+                ("description", "=", key),
+                ("create_date", ">=", fields.Datetime.to_string(limit_date)),
+            ],
+            limit=1,
+        )
+
+    def _label_cached_report_attachment(self, key):
+        """Marca el attachment recién generado para poder reusarlo en el próximo
+        recálculo. Si el core generó más de uno (por el hook de contabilidad, por
+        ejemplo) no marcamos nada y el reuso simplemente no aplica."""
+        self.ensure_one()
+        new_attachments = self.attachment_ids.filtered(
+            lambda attachment: attachment.res_model == "mail.compose.message"
+            and not attachment.res_id
+            and not attachment.description
+        )
+        if len(new_attachments) == 1:
+            new_attachments.description = key
 
     def _manage_mail_values(self, mail_values_all):
         """


### PR DESCRIPTION
Rendering a PDF report is circular today: wkhtmltopdf resolves the report asset links (and the barcode images, when the report has any) against `base_url`, that is, against the very same Odoo instance. So a render **occupies one HTTP worker and needs another free one to answer itself**.

On an instance with `workers = 3`, three concurrent renders exhaust the three workers, nobody calls `accept()`, the backlog fills up and the port stops accepting connections. Everything stays blocked until `limit_time_real` (300s), but the liveness probe (`tcpSocket` 8069, 15s × 8) kills the container at 120s — so the pod never gets to recover by itself and the whole service goes down for 2 to 4 minutes.

The composer of a mail template amplifies it: `attachment_ids` is a compute with `store=True, readonly=False`, so the web client recomputes it on every round trip while the composer is opening, and each recompute renders the same PDF again.

Two independent changes, one per module.

### `base_ux`: the report html no longer calls the instance back

`_prepare_html` post-processes the html handed to wkhtmltopdf:

* the report asset bundles are inlined as a `<style>` tag;
* the `@font-face` rules pointing back at the instance are dropped, keeping the `font-family` declarations. wkhtmltopdf resolves those families from the system fonts of the image that runs it;
* the `/report/barcode/` images are embedded as data URIs, resolved in process through `ir.actions.report.barcode()` — the same code the controller uses.

Anything that cannot be resolved is left exactly as it was, so a report never fails because of this. It can be turned off with the system parameter `base_ux.report_self_contained`.

### `mail_ux`: one render per composer, not 2 to 6

`_compute_attachment_ids` reuses the attachment already generated for the same report, the same record and the same `write_date` of that record, as long as it is still orphan (`res_model = mail.compose.message`, `res_id = 0`), was created by the same user and falls inside the reuse window. This also stops the orphan attachments from piling up in the database on every opening of the composer.

The reuse only kicks in for the case that causes the problem and that is unambiguous: comment mode over a single record with a single qweb report on the template. With more than one report there is no way to tell which created attachment belongs to which report, so core resolves it.

The window bounds how long a change that the report shows but that does not touch the record's own `write_date` (partner data, company data, a translation) could be seen stale. System parameter `mail_ux.report_attachment_cache_ttl`, 600 seconds by default, 0 disables the reuse.

## Why this approach

* **Raising `workers` does not close the door**, it only moves the threshold: an instance with 8 effective workers (`workers = 4`, `replicas = 2`) hit the same deadlock. And it would mean paying for capacity to render the same PDF several times.
* **Lowering `limit_time_real` below the probe's 120s** would turn the outage into a recycled worker, but it leaves the deadlock in place and it is a platform side setting, not a fix.
* **Adding a timeout and cancellation on the PDF service** only changes *how* it fails ("the PDF failed" instead of "the instance is down for 5 minutes"). It does not make the PDF come out. Tracked separately on the platform side.

## Measurements

Taken from the access logs of a production 19.0 instance, over a 9 hour window:

* **259** renders and **508** requests to `/web/assets/*report_assets*`, all of them coming from the loopback address — exactly **2 self-requests per render**, which is what this PR removes.
* **0** requests to `/web/static/fonts/` from that same loop, which is what makes dropping the local `@font-face` rules safe: nothing asks for those files today.
* Between 13% and 36% of the renders of any instance are the same document generated 2 to 6 times within seconds — the recompute storm this PR stops.

## Test plan

* Open the mail composer on a purchase order (or any record with a mail template carrying a report), close it and open it again. The log must show **one** `The PDF report has been generated` per opening, and `ir.attachment` must not grow by 2 to 4 orphan rows each time.
* Edit the record and reopen the composer: the PDF must be generated again.
* Print any report and check the html handed to wkhtmltopdf has no `<link>` to `/web/assets/` and no `src="/report/barcode/"`. On the instance side, no request from the loopback address to `/web/assets/*report_assets*` during the render.
* Print a report that carries a barcode or a QR code (a delivery slip, an invoice) and check the image comes out.
* Set `base_ux.report_self_contained` to `0` and `mail_ux.report_attachment_cache_ttl` to `0`: both behaviours must fall back to core.

Verified end to end against the same PDF service used in production: the report renders with the expected styling and page layout, with the text fonts resolved from the system.

The html of each rendered document grows by around 400 KB, the size of the inlined bundles.

Internal reference: https://www.adhoc.inc/odoo/helpdesk.ticket/126274
